### PR TITLE
Update client producer, add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
 				-X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
 
 $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
-	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --default-consumes application/json
-	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A timestamp_server --flag-strategy=pflag --default-produces application/json
+	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated
+	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A timestamp_server --flag-strategy=pflag
 
 .PHONY: validate-openapi
 validate-openapi: $(SWAGGER)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,11 +23,6 @@ host: timestamp.sigstore.dev
 schemes:
   - http
 
-consumes:
-  - application/json
-produces:
-  - application/json
-
 paths:
   /api/v1/timestamp:
     post:
@@ -66,6 +61,8 @@ paths:
       operationId: getTimestampCertChain
       tags:
         - timestamp
+      consumes:
+        - application/json
       produces:
         - application/pem-certificate-chain
       responses:

--- a/pkg/client/timestamp_client.go
+++ b/pkg/client/timestamp_client.go
@@ -31,7 +31,10 @@ func GetTimestampClient(timestampServerURL string, opts ...Option) (*client.Time
 	o := makeOptions(opts...)
 
 	rt := httptransport.New(url.Host, client.DefaultBasePath, []string{url.Scheme})
+	// Input to server
 	rt.Producers["application/timestamp-query"] = runtime.ByteStreamProducer()
+	rt.Producers["application/json"] = runtime.JSONProducer()
+	// Output from server
 	rt.Consumers["application/timestamp-reply"] = runtime.ByteStreamConsumer()
 	rt.Consumers["application/pem-certificate-chain"] = runtime.TextConsumer()
 

--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -58,8 +58,6 @@ func configureAPI(api *operations.TimestampServerAPI) http.Handler {
 	// api.UseRedoc()
 
 	api.JSONConsumer = runtime.JSONConsumer()
-	api.JSONProducer = runtime.JSONProducer()
-
 	api.ApplicationPemCertificateChainProducer = runtime.TextProducer()
 	api.ApplicationTimestampQueryConsumer = runtime.ByteStreamConsumer()
 	api.ApplicationTimestampReplyProducer = runtime.ByteStreamProducer()

--- a/pkg/generated/restapi/doc.go
+++ b/pkg/generated/restapi/doc.go
@@ -30,7 +30,6 @@
 //	Produces:
 //	  - application/pem-certificate-chain
 //	  - application/timestamp-reply
-//	  - application/json
 //
 // swagger:meta
 package restapi

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -33,12 +33,6 @@ var (
 
 func init() {
 	SwaggerJSON = json.RawMessage([]byte(`{
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
   "schemes": [
     "http"
   ],
@@ -97,6 +91,9 @@ func init() {
     "/api/v1/timestamp/certchain": {
       "get": {
         "description": "Returns the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/pem-certificate-chain"
         ],
@@ -157,12 +154,6 @@ func init() {
   }
 }`))
 	FlatSwaggerJSON = json.RawMessage([]byte(`{
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
   "schemes": [
     "http"
   ],
@@ -227,6 +218,9 @@ func init() {
     "/api/v1/timestamp/certchain": {
       "get": {
         "description": "Returns the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/pem-certificate-chain"
         ],

--- a/pkg/generated/restapi/operations/timestamp_server_api.go
+++ b/pkg/generated/restapi/operations/timestamp_server_api.go
@@ -67,7 +67,6 @@ func NewTimestampServerAPI(spec *loads.Document) *TimestampServerAPI {
 		ApplicationTimestampReplyProducer: runtime.ProducerFunc(func(w io.Writer, data interface{}) error {
 			return errors.NotImplemented("applicationTimestampReply producer has not yet been implemented")
 		}),
-		JSONProducer: runtime.JSONProducer(),
 
 		TimestampGetTimestampCertChainHandler: timestamp.GetTimestampCertChainHandlerFunc(func(params timestamp.GetTimestampCertChainParams) middleware.Responder {
 			return middleware.NotImplemented("operation timestamp.GetTimestampCertChain has not yet been implemented")
@@ -116,9 +115,6 @@ type TimestampServerAPI struct {
 	// ApplicationTimestampReplyProducer registers a producer for the following mime types:
 	//   - application/timestamp-reply
 	ApplicationTimestampReplyProducer runtime.Producer
-	// JSONProducer registers a producer for the following mime types:
-	//   - application/json
-	JSONProducer runtime.Producer
 
 	// TimestampGetTimestampCertChainHandler sets the operation handler for the get timestamp cert chain operation
 	TimestampGetTimestampCertChainHandler timestamp.GetTimestampCertChainHandler
@@ -206,9 +202,6 @@ func (o *TimestampServerAPI) Validate() error {
 	if o.ApplicationTimestampReplyProducer == nil {
 		unregistered = append(unregistered, "ApplicationTimestampReplyProducer")
 	}
-	if o.JSONProducer == nil {
-		unregistered = append(unregistered, "JSONProducer")
-	}
 
 	if o.TimestampGetTimestampCertChainHandler == nil {
 		unregistered = append(unregistered, "timestamp.GetTimestampCertChainHandler")
@@ -268,8 +261,6 @@ func (o *TimestampServerAPI) ProducersFor(mediaTypes []string) map[string]runtim
 			result["application/pem-certificate-chain"] = o.ApplicationPemCertificateChainProducer
 		case "application/timestamp-reply":
 			result["application/timestamp-reply"] = o.ApplicationTimestampReplyProducer
-		case "application/json":
-			result["application/json"] = o.JSONProducer
 		}
 
 		if p, ok := o.customProducers[mt]; ok {


### PR DESCRIPTION
This removes the default consumer/producer statements, since JSON wasn't ever produced.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->