### PR TITLE
Add inspect cli cmd

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
           go-version-file: './go.mod'
           check-latest: true
       - name: Build timestamp CLI
-        run: make bin/timestamp-cli
+        run: make timestamp-cli
       - name: Run Go tests
         run: go test -covermode atomic -coverprofile coverage.txt $(go list ./... | grep -v third_party/)
       - name: Upload Coverage Report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
           go-version-file: './go.mod'
           check-latest: true
       - name: Build timestamp CLI
-        run: make timestamp-cli
+        run: make bin/timestamp-cli
       - name: Run Go tests
         run: go test -covermode atomic -coverprofile coverage.txt $(go list ./... | grep -v third_party/)
       - name: Upload Coverage Report

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ timestamp-cli
 timestamp-server
 *.tsr
 hack/tools/bin/*
+bin/timestamp-cli

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ dist/*
 timestampCLIImagerefs
 timestampServerImagerefs
 fetchTSAImagerefs
-timestamp-cli
-timestamp-server
 *.tsr
 hack/tools/bin/*
-bin/timestamp-cli
+bin/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 .PHONY: all test clean clean-gen lint gosec ko ko-local
 
-all: timestamp-cli timestamp-server
+all: bin/timestamp-cli bin/timestamp-server
 
 GENSRC = pkg/generated/client/%.go pkg/generated/models/%.go pkg/generated/restapi/%.go
 OPENAPIDEPS = openapi.yaml
@@ -69,19 +69,19 @@ gosec:
 
 gen: $(GENSRC)
 
-timestamp-cli: $(SRCS)
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(CLI_LDFLAGS)" -o timestamp-cli ./cmd/timestamp-cli
+bin/timestamp-cli: $(SRCS)
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(CLI_LDFLAGS)" -o bin/timestamp-cli ./cmd/timestamp-cli
 
-timestamp-server: $(SRCS)
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o timestamp-server ./cmd/timestamp-server
+bin/timestamp-server: $(SRCS)
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o bin/timestamp-server ./cmd/timestamp-server
 
-test: timestamp-cli
+test: bin/timestamp-cli
 	go test ./...
 
 clean:
 	rm -rf dist
 	rm -rf hack/tools/bin
-	rm -rf timestamp-cli timestamp-server
+	rm -rf bin/timestamp-cli bin/timestamp-server
 
 clean-gen: clean
 	rm -rf $(shell find pkg/generated -iname "*.go"|grep -v pkg/generated/restapi/configure_timestamp_server.go)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 .PHONY: all test clean clean-gen lint gosec ko ko-local
 
-all: bin/timestamp-cli bin/timestamp-server
+all: timestamp-cli timestamp-server
 
 GENSRC = pkg/generated/client/%.go pkg/generated/models/%.go pkg/generated/restapi/%.go
 OPENAPIDEPS = openapi.yaml
@@ -69,13 +69,13 @@ gosec:
 
 gen: $(GENSRC)
 
-bin/timestamp-cli: $(SRCS)
+timestamp-cli: $(SRCS)
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(CLI_LDFLAGS)" -o bin/timestamp-cli ./cmd/timestamp-cli
 
-bin/timestamp-server: $(SRCS)
+timestamp-server: $(SRCS)
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o bin/timestamp-server ./cmd/timestamp-server
 
-test: bin/timestamp-cli
+test: timestamp-cli
 	go test ./...
 
 clean:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ brew install openssl
 
 To launch the server:
 * `docker-compose up`
-* `go build ./cmd/timestamp-server && ./timestamp-server serve`
+* `go build ./cmd/timestamp-server && ./bin/timestamp-server serve`
 
 Both of these commands launch a server with an in-memory signing key and certificate chain. **This should not
 be used for production.**
@@ -25,10 +25,10 @@ To fetch a timestamp:
 1. Retrieve the verification chain: `curl localhost:3000/api/v1/timestamp/certchain > ts_chain.pem`
 1. Build client: `go build ./cmd/timestamp-cli`
 1. Create test blob to sign: `echo "myblob" > myblob`
-1. Fetch timestamp: `./timestamp-cli --timestamp_server http://localhost:3000 timestamp --hash sha256 --artifact myblob --out response.tsr`
+1. Fetch timestamp: `./bin/timestamp-cli --timestamp_server http://localhost:3000 timestamp --hash sha256 --artifact myblob --out response.tsr`
 1. Verify timestamp with either openssl or with the timestamp cli: 
   - `openssl ts -verify -in response.tsr -data "myblob" -CAfile ts_chain.pem`
-  - `./timestamp-cli verify --timestamp response.tsr --artifact "myblob" --cert-chain ts_chain.pem`
+  - `./bin/timestamp-cli verify --timestamp response.tsr --artifact "myblob" --cert-chain ts_chain.pem`
 1. Inspect timestamp: `openssl ts -reply -in response.tsr -text`
 
 ## Production deployment

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To fetch a timestamp:
 1. Verify timestamp with either openssl or with the timestamp cli: 
   - `openssl ts -verify -in response.tsr -data "myblob" -CAfile ts_chain.pem`
   - `./bin/timestamp-cli verify --timestamp response.tsr --artifact "myblob" --cert-chain ts_chain.pem`
-1. Inspect timestamp: `openssl ts -reply -in response.tsr -text`
+1. Inspect timestamp with either openssl or with the timestamp cli:
+  - `openssl ts -reply -in response.tsr -text`
+  - `./bin/timestamp-cli inspect --timestamp response.tsr --format json`
 
 ## Production deployment
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ brew install openssl
 
 To launch the server:
 * `docker-compose up`
-* `go build ./cmd/timestamp-server && ./bin/timestamp-server serve`
+* `go build ./cmd/timestamp-server && ./cmd/timestamp-server serve`
 
 Both of these commands launch a server with an in-memory signing key and certificate chain. **This should not
 be used for production.**

--- a/cmd/timestamp-cli/app/inspect.go
+++ b/cmd/timestamp-cli/app/inspect.go
@@ -1,0 +1,87 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/digitorus/pkcs7"
+	"github.com/digitorus/timestamp"
+	"github.com/sigstore/timestamp-authority/cmd/timestamp-cli/app/format"
+	"github.com/sigstore/timestamp-authority/pkg/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func addInspectFlags(cmd *cobra.Command) {
+	cmd.Flags().Var(NewFlagValue(fileFlag, ""), "timestamp", "path to timestamp response to inspect")
+	cmd.MarkFlagRequired("timestamp") //nolint:errcheck
+	cmd.Flags().Var(NewFlagValue(formatFlag, ""), "format", "output format")
+	cmd.MarkFlagRequired("format") //nolint:errcheck
+}
+
+type inspectCmdOutput struct {
+	TimestampResponse timestamp.Timestamp
+	Token             pkcs7.PKCS7
+}
+
+func (t *inspectCmdOutput) String() string {
+	return fmt.Sprintf("%+v", t.TimestampResponse)
+}
+
+var inspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Inspect timestamp",
+	Long:  "Inspect the signed timestamp response.",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			log.CliLogger.Fatal("Error initializing cmd line args: ", err)
+		}
+		return nil
+	},
+	Run: format.WrapCmd(func(args []string) (interface{}, error) {
+		tsr := viper.GetString("timestamp")
+		tsrBytes, err := os.ReadFile(filepath.Clean(tsr))
+		if err != nil {
+			return nil, fmt.Errorf("error reading request from file: %w", err)
+		}
+
+		log.CliLogger.Info("get tsr bytes")
+
+		ts, err := timestamp.ParseResponse(tsrBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		token, err := pkcs7.Parse(ts.RawToken)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing hashed message: %w", err)
+		}
+
+		return &inspectCmdOutput{
+			TimestampResponse: *ts,
+			Token:             *token,
+		}, nil
+	}),
+}
+
+func init() {
+	initializePFlagMap()
+	addInspectFlags(inspectCmd)
+	rootCmd.AddCommand(inspectCmd)
+}

--- a/cmd/timestamp-cli/app/inspect.go
+++ b/cmd/timestamp-cli/app/inspect.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/digitorus/pkcs7"
 	"github.com/digitorus/timestamp"
 	"github.com/sigstore/timestamp-authority/cmd/timestamp-cli/app/format"
 	"github.com/sigstore/timestamp-authority/pkg/log"
@@ -37,7 +36,6 @@ func addInspectFlags(cmd *cobra.Command) {
 
 type inspectCmdOutput struct {
 	TimestampResponse timestamp.Timestamp
-	Token             pkcs7.PKCS7
 }
 
 func (t *inspectCmdOutput) String() string {
@@ -58,24 +56,16 @@ var inspectCmd = &cobra.Command{
 		tsr := viper.GetString("timestamp")
 		tsrBytes, err := os.ReadFile(filepath.Clean(tsr))
 		if err != nil {
-			return nil, fmt.Errorf("error reading request from file: %w", err)
+			return nil, fmt.Errorf("Error reading request from TSR file: %w", err)
 		}
-
-		log.CliLogger.Info("get tsr bytes")
 
 		ts, err := timestamp.ParseResponse(tsrBytes)
 		if err != nil {
 			return nil, err
 		}
 
-		token, err := pkcs7.Parse(ts.RawToken)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing hashed message: %w", err)
-		}
-
 		return &inspectCmdOutput{
 			TimestampResponse: *ts,
-			Token:             *token,
 		}, nil
 	}),
 }

--- a/pkg/tests/cli_test.go
+++ b/pkg/tests/cli_test.go
@@ -46,10 +46,13 @@ func TestInspect(t *testing.T) {
 	out := runCli(t, "inspect", "--timestamp", tsrPath, "--format", "json")
 
 	// test that output can be parsed as a timestamp
-	var timestamp ts.Timestamp
-	err := json.Unmarshal([]byte(out), &timestamp)
+	resp := struct {
+		TimestampResponse ts.Timestamp
+	}{}
+
+	err := json.Unmarshal([]byte(out), &resp)
 	if err != nil {
-		t.Errorf("failed to parse CLI response to a timestamp")
+		t.Errorf("failed to parse CLI response to a timestamp: %v", err)
 	}
 }
 

--- a/pkg/tests/cli_test.go
+++ b/pkg/tests/cli_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	cli = "../../timestamp-cli"
+	cli = "../../bin/timestamp-cli"
 )
 
 func TestTimestampCreation(t *testing.T) {

--- a/pkg/tests/cli_test.go
+++ b/pkg/tests/cli_test.go
@@ -18,6 +18,7 @@ package tests
 import (
 	"bytes"
 	"crypto"
+	"encoding/json"
 	"errors"
 	"io"
 	"math/big"
@@ -36,7 +37,23 @@ const (
 	cli = "../../bin/timestamp-cli"
 )
 
-func TestTimestampCreation(t *testing.T) {
+func TestInspect(t *testing.T) {
+	serverURL := createServer(t)
+
+	tsrPath := getTimestamp(t, serverURL, "blob")
+
+	// It should create timestamp successfully.
+	out := runCli(t, "inspect", "--timestamp", tsrPath, "--format", "json")
+
+	// test that output can be parsed as a timestamp
+	var timestamp ts.Timestamp
+	err := json.Unmarshal([]byte(out), &timestamp)
+	if err != nil {
+		t.Errorf("failed to parse CLI response to a timestamp")
+	}
+}
+
+func TestTimestamp(t *testing.T) {
 	restapiURL := createServer(t)
 
 	tsrPath := filepath.Join(t.TempDir(), "response.tsr")
@@ -52,7 +69,7 @@ func TestTimestampCreation(t *testing.T) {
 	}
 }
 
-func TestTimestampVerify(t *testing.T) {
+func TestVerify(t *testing.T) {
 	restapiURL := createServer(t)
 
 	artifactContent := "blob"
@@ -68,7 +85,7 @@ func TestTimestampVerify(t *testing.T) {
 	outputContains(t, out, "Successfully verified timestamp")
 }
 
-func TestTimestampVerify_InvalidTSR(t *testing.T) {
+func TestVerify_InvalidTSR(t *testing.T) {
 	restapiURL := createServer(t)
 
 	pemPath := filepath.Join(t.TempDir(), "ts_chain.pem")
@@ -90,7 +107,7 @@ func TestTimestampVerify_InvalidTSR(t *testing.T) {
 	outputContains(t, out, "Error parsing response into Timestamp")
 }
 
-func TestTimestampVerify_InvalidPEM(t *testing.T) {
+func TestVerify_InvalidPEM(t *testing.T) {
 	restapiURL := createServer(t)
 
 	artifactContent := "blob"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/timestamp-authority/issues/39 by adding an `inspect` command to the CLI that enables the user to inspect a timestamp response.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->