### PR TITLE
Fix extension bug, add more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
 				-X sigs.k8s.io/release-utils/version.gitTreeState=$(GIT_TREESTATE) \
 				-X sigs.k8s.io/release-utils/version.buildDate=$(BUILD_DATE)
 
+CLI_LDFLAGS=$(LDFLAGS)
+SERVER_LDFLAGS=$(LDFLAGS)
+
 $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
 	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated
 	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A timestamp_server --flag-strategy=pflag

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -55,8 +55,7 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 		// Not qualified for the european directive
 		Qualified:         false,
 		AddTSACertificate: req.Certificates,
-		ExtraExtensions:   req.ExtraExtensions,
-		Certificates:      api.certChain,
+		ExtraExtensions:   req.Extensions,
 	}
 
 	resp, err := tsStruct.CreateResponse(api.certChain[0], api.tsaSigner)

--- a/pkg/tests/api_test.go
+++ b/pkg/tests/api_test.go
@@ -17,6 +17,8 @@ package tests
 import (
 	"bytes"
 	"crypto"
+	"crypto/sha256"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"io"
 	"math/big"
@@ -77,6 +79,7 @@ func TestGetTimestampResponse(t *testing.T) {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}
 
+	// create request with nonce and certificate, the typical request structure
 	tsNonce := big.NewInt(1234)
 	tsq, err := ts.CreateRequest(strings.NewReader("blob"), &ts.RequestOptions{
 		Hash:         crypto.SHA256,
@@ -94,7 +97,7 @@ func TestGetTimestampResponse(t *testing.T) {
 	var respBytes bytes.Buffer
 	_, err = c.Timestamp.GetTimestampResponse(params, &respBytes)
 	if err != nil {
-		t.Fatalf("unexpected error getting timestamp chain: %v", err)
+		t.Fatalf("unexpected error getting timestamp response: %v", err)
 	}
 
 	tsr, err := ts.ParseResponse(respBytes.Bytes())
@@ -102,28 +105,150 @@ func TestGetTimestampResponse(t *testing.T) {
 		t.Fatalf("unexpected error parsing response: %v", err)
 	}
 
+	// check certificate fields
 	if len(tsr.Certificates) != 1 {
 		t.Fatalf("expected 1 certificate, got %d", len(tsr.Certificates))
 	}
 	if !tsr.AddTSACertificate {
 		t.Fatalf("expected TSA certificate")
 	}
+	// check nonce
 	if tsr.Nonce.Cmp(tsNonce) != 0 {
 		t.Fatalf("expected nonce %d, got %d", tsNonce, tsr.Nonce)
 	}
+	// check hash and hashed message
 	if tsr.HashAlgorithm != crypto.SHA256 {
 		t.Fatalf("unexpected hash algorithm")
 	}
-	if tsr.Accuracy <= 0 {
-		t.Fatalf("expected greater than zero accurary, got %v", tsr.Accuracy)
+	hashedMessage := sha256.Sum256([]byte("blob"))
+	if !bytes.Equal(tsr.HashedMessage, hashedMessage[:]) {
+		t.Fatalf("expected hashed messages to be equal: %v %v", tsr.HashedMessage, hashedMessage)
 	}
+	// check time and accuracy
+	if tsr.Time.After(time.Now()) {
+		t.Fatalf("expected time to be set to a previous time")
+	}
+	duration, _ := time.ParseDuration("1s")
+	if tsr.Accuracy != duration {
+		t.Fatalf("expected 1s accuracy, got %v", tsr.Accuracy)
+	}
+	// check serial number
 	if tsr.SerialNumber.Cmp(big.NewInt(0)) == 0 {
 		t.Fatalf("expected serial number, got 0")
 	}
+	// check ordering and qualified defaults
 	if tsr.Qualified {
 		t.Fatalf("tsr should not be qualified")
 	}
+	if tsr.Ordering {
+		t.Fatalf("tsr should not be ordered")
+	}
+	// check policy OID default
 	if !tsr.Policy.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 2}) {
 		t.Fatalf("unexpected policy ID")
+	}
+	// check for no extensions
+	if len(tsr.Extensions) != 0 {
+		t.Fatalf("expected 0 extensions, got %d", len(tsr.Extensions))
+	}
+}
+
+func TestGetTimestampResponseWithExtsAndOID(t *testing.T) {
+	url := createServer(t)
+
+	c, err := client.GetTimestampClient(url)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	// create request with nonce and certificate, the typical request structure
+	tsNonce := big.NewInt(1234)
+	tsq, err := ts.CreateRequest(strings.NewReader("blob"), &ts.RequestOptions{
+		Hash:         crypto.SHA256,
+		Certificates: true,
+		Nonce:        tsNonce,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+	// populate additional request parameters for extensions and OID - atypical request structure
+	req, err := ts.ParseRequest(tsq)
+	if err != nil {
+		t.Fatalf("unexpected error parsing request: %v", err)
+	}
+	req.ExtraExtensions = []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte{1, 2, 3, 4}}}
+	fakePolicyOID := asn1.ObjectIdentifier{1, 2, 3, 4, 5}
+	req.TSAPolicyOID = fakePolicyOID
+	tsq, err = req.Marshal()
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+
+	params := timestamp.NewGetTimestampResponseParams()
+	params.SetTimeout(10 * time.Second)
+	params.Request = io.NopCloser(bytes.NewReader(tsq))
+
+	var respBytes bytes.Buffer
+	_, err = c.Timestamp.GetTimestampResponse(params, &respBytes)
+	if err != nil {
+		t.Fatalf("unexpected error getting timestamp response: %v", err)
+	}
+
+	tsr, err := ts.ParseResponse(respBytes.Bytes())
+	if err != nil {
+		t.Fatalf("unexpected error parsing response: %v", err)
+	}
+
+	// check policy OID
+	if !tsr.Policy.Equal(fakePolicyOID) {
+		t.Fatalf("unexpected policy ID")
+	}
+	// check extension is present
+	if len(tsr.Extensions) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(tsr.Extensions))
+	}
+}
+
+func TestGetTimestampResponseWithNoCertificateOrNonce(t *testing.T) {
+	url := createServer(t)
+
+	c, err := client.GetTimestampClient(url)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	tsq, err := ts.CreateRequest(strings.NewReader("blob"), &ts.RequestOptions{
+		Hash:         crypto.SHA256,
+		Certificates: false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+
+	params := timestamp.NewGetTimestampResponseParams()
+	params.SetTimeout(10 * time.Second)
+	params.Request = io.NopCloser(bytes.NewReader(tsq))
+
+	var respBytes bytes.Buffer
+	_, err = c.Timestamp.GetTimestampResponse(params, &respBytes)
+	if err != nil {
+		t.Fatalf("unexpected error getting timestamp response: %v", err)
+	}
+
+	tsr, err := ts.ParseResponse(respBytes.Bytes())
+	if err != nil {
+		t.Fatalf("unexpected error parsing response: %v", err)
+	}
+
+	// check certificate fields
+	if len(tsr.Certificates) != 0 {
+		t.Fatalf("expected 0 certificates, got %d", len(tsr.Certificates))
+	}
+	if tsr.AddTSACertificate {
+		t.Fatalf("expected no TSA certificate")
+	}
+	// check nonce
+	if tsr.Nonce != nil {
+		t.Fatalf("expected no nonce, got %d", tsr.Nonce)
 	}
 }


### PR DESCRIPTION
* Fix bug where we were reading ExtraExtensions rather than Extensions from the request. The latter is what's set after unmarshalling.
* Drop Certificates from being set, it's not read when marshalling
* Add tests for all 12 fields that will can be set.
* Add tests for custom OIDs and extensions, and dropping nonce and cert
* Update CLI test to only verify with CA certificates
* Update Makefile to define LDFLAGS for CLI and server

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->