### PR TITLE
Update oid

### DIFF
--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -39,8 +39,7 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 
 	policyID := req.TSAPolicyOID
 	if policyID.String() == "" {
-		// https://datatracker.ietf.org/doc/html/rfc3628#section-5.2
-		policyID = asn1.ObjectIdentifier{0, 4, 0, 2023, 1, 1}
+		policyID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 2}
 	}
 
 	duration, _ := time.ParseDuration("1s")

--- a/pkg/tests/api_test.go
+++ b/pkg/tests/api_test.go
@@ -123,7 +123,7 @@ func TestGetTimestampResponse(t *testing.T) {
 	if tsr.Qualified {
 		t.Fatalf("tsr should not be qualified")
 	}
-	if !tsr.Policy.Equal(asn1.ObjectIdentifier{0, 4, 0, 2023, 1, 1}) {
+	if !tsr.Policy.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 2}) {
 		t.Fatalf("unexpected policy ID")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Meredith Lancaster <malancas@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Update the OID to match the one specified in https://github.com/sigstore/timestamp-authority/issues/2.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->