### PR TITLE
Require the file signer to specify the certificate chain

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -64,8 +64,8 @@ func init() {
 	rootCmd.PersistentFlags().String("tink-key-resource", "", "KMS key for signing timestamp responses for Tink keysets. Valid options include: [gcp-kms://resource, aws-kms://resource, hcvault://]")
 	rootCmd.PersistentFlags().String("tink-keyset-path", "", "Path to KMS-encrypted keyset for Tink, decrypted by tink-key-resource")
 	rootCmd.PersistentFlags().String("tink-hcvault-token", "", "Authentication token for Hashicorp Vault API calls")
-	// KMS and Tink flags
-	rootCmd.PersistentFlags().String("certificate-chain-path", "", "Path to PEM-encoded certificate chain certifying the kms-key-resource or tink-key-resource to act as a timestamping authority")
+	// KMS, Tink and File flags
+	rootCmd.PersistentFlags().String("certificate-chain-path", "", "Path to PEM-encoded certificate chain certifying the kms-key-resource, tink-key-resource, or file-signer-key-path to act as a timestamping authority")
 	// File flags
 	rootCmd.PersistentFlags().String("file-signer-key-path", "", "Path to file containing PEM-encoded private key. Supported formats include PKCS#1, PKCS#8, and RFC5915 for EC")
 	rootCmd.PersistentFlags().String("file-signer-passwd", "", "Password to decrypt private key")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,7 +53,8 @@ func NewAPI() (*API, error) {
 
 	var certChain []*x509.Certificate
 
-	if viper.GetString("timestamp-signer") == signer.KMSScheme || viper.GetString("timestamp-signer") == signer.TinkScheme {
+	// KMS, Tink and File signers require a provided certificate chain
+	if viper.GetString("timestamp-signer") != signer.MemoryScheme {
 		certChainPath := viper.GetString("certificate-chain-path")
 		data, err := os.ReadFile(filepath.Clean(certChainPath))
 		if err != nil {


### PR DESCRIPTION
This is necessary because otherwise, a new cert chain would get generated in-memory on every startup.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->