### PR TITLE
fix setting certChain.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -60,7 +60,7 @@ func NewAPI() (*API, error) {
 		if err != nil {
 			return nil, err
 		}
-		certChain, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(data))
+		certChain, err = cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix a bug where certChain was being recreated, therefore setting it in the if clause being invisible. Basically it doesn't work on that path.


#### Release Note
* Fix a bug where certChain was not set correctly.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->