### PR TITLE
inspect: remove format flag

### DIFF
--- a/cmd/timestamp-cli/app/inspect.go
+++ b/cmd/timestamp-cli/app/inspect.go
@@ -30,7 +30,7 @@ import (
 func addInspectFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(NewFlagValue(fileFlag, ""), "timestamp", "path to timestamp response to inspect")
 	cmd.MarkFlagRequired("timestamp") //nolint:errcheck
-	cmd.Flags().Var(NewFlagValue(formatFlag, ""), "format", "output format")
+	cmd.Flags().Var(NewFlagValue(formatFlag, "default"), "format", "output format")
 	cmd.MarkFlagRequired("format") //nolint:errcheck
 }
 

--- a/cmd/timestamp-cli/app/inspect.go
+++ b/cmd/timestamp-cli/app/inspect.go
@@ -30,7 +30,6 @@ import (
 func addInspectFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(NewFlagValue(fileFlag, ""), "timestamp", "path to timestamp response to inspect")
 	cmd.MarkFlagRequired("timestamp") //nolint:errcheck
-	cmd.Flags().Var(NewFlagValue(formatFlag, "default"), "format", "output format")
 }
 
 type inspectCmdOutput struct {

--- a/cmd/timestamp-cli/app/inspect.go
+++ b/cmd/timestamp-cli/app/inspect.go
@@ -31,7 +31,6 @@ func addInspectFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(NewFlagValue(fileFlag, ""), "timestamp", "path to timestamp response to inspect")
 	cmd.MarkFlagRequired("timestamp") //nolint:errcheck
 	cmd.Flags().Var(NewFlagValue(formatFlag, "default"), "format", "output format")
-	cmd.MarkFlagRequired("format") //nolint:errcheck
 }
 
 type inspectCmdOutput struct {


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
We didn't set any default format, so it is hard to know which options are available for the format.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fix: set default format value for the inspect' format flag.
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->