### PR TITLE
Added .PHONY target for CLI rebuilding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ gosec:
 	$(GOBIN)/gosec ./...
 
 gen: $(GENSRC)
-
+.PHONY : timestamp-cli
 timestamp-cli: $(SRCS)
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(CLI_LDFLAGS)" -o bin/timestamp-cli ./cmd/timestamp-cli
 


### PR DESCRIPTION

Signed-off-by: Neil Naveen <42328488+neilnaveen@users.noreply.github.com>

#### Summary
- #135 Added .PHONY target to timestamp-cli so that the ClI would be rebuilt every time we run make 

#### Release Note
NONE
#### Documentation
NONE
