### PR TITLE
Verify command returns the parsed timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To fetch a timestamp with the provided `timestamp-cli`:
 1. Create test blob to sign: `echo "myblob" > myblob`
 1. Build client: `make timestamp-cli`
 1. Fetch timestamp: `./bin/timestamp-cli --timestamp_server http://localhost:3000 timestamp --hash sha256 --artifact myblob --out response.tsr`
-1. Verify timestamp: `./bin/timestamp-cli verify --timestamp response.tsr --artifact "myblob" --certificate-chain ts_chain.pem`
+1. Verify timestamp: `./bin/timestamp-cli verify --timestamp response.tsr --artifact "myblob" --certificate-chain ts_chain.pem --format json`
 1. Inspect timestamp: `./bin/timestamp-cli inspect --timestamp response.tsr --format json`
 
 To fetch a timestamp with `openssl` and `curl`:

--- a/cmd/timestamp-cli/app/verify.go
+++ b/cmd/timestamp-cli/app/verify.go
@@ -34,7 +34,7 @@ import (
 )
 
 type verifyCmdOutput struct {
-	TimestampPath string
+	TimestampPath   string
 	ParsedTimestamp timestamp.Timestamp
 }
 

--- a/cmd/timestamp-cli/app/verify.go
+++ b/cmd/timestamp-cli/app/verify.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/digitorus/timestamp"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/timestamp-authority/cmd/timestamp-cli/app/format"
 	"github.com/sigstore/timestamp-authority/pkg/log"
@@ -34,6 +35,7 @@ import (
 
 type verifyCmdOutput struct {
 	TimestampPath string
+	ParsedTimestamp timestamp.Timestamp
 }
 
 func (v *verifyCmdOutput) String() string {
@@ -86,9 +88,12 @@ func runVerify() (interface{}, error) {
 		return verifyCmdOutput{TimestampPath: tsrPath}, fmt.Errorf("failed to created VerifyOpts: %w", err)
 	}
 
-	err = verification.VerifyTimestampResponse(tsrBytes, artifact, opts)
+	ts, err := verification.VerifyTimestampResponse(tsrBytes, artifact, opts)
+	if err != nil {
+		return verifyCmdOutput{TimestampPath: tsrPath}, fmt.Errorf("failed to verify timestamp: %w", err)
+	}
 
-	return &verifyCmdOutput{TimestampPath: tsrPath}, err
+	return &verifyCmdOutput{TimestampPath: tsrPath, ParsedTimestamp: *ts}, nil
 }
 
 func newVerifyOpts() (verification.VerifyOpts, error) {

--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -219,29 +219,24 @@ func VerifyTimestampResponse(tsrBytes []byte, artifact io.Reader, opts VerifyOpt
 	}
 
 	// verify the timestamp response signature using the provided certificate pool
-	err = verifyTSRWithChain(ts, opts)
-	if err != nil {
+	if err = verifyTSRWithChain(ts, opts); err != nil {
 		return nil, err
 	}
 
-	err = verifyNonce(ts.Nonce, opts)
-	if err != nil {
+	if err = verifyNonce(ts.Nonce, opts); err != nil {
 		return nil, err
 	}
 
-	err = verifyOID(ts.Policy, opts)
-	if err != nil {
+	if err = verifyOID(ts.Policy, opts); err != nil {
 		return nil, err
 	}
 
-	err = verifyLeafCert(*ts, opts)
-	if err != nil {
+	if err = verifyLeafCert(*ts, opts); err != nil {
 		return nil, err
 	}
 
 	// verify the hash in the timestamp response matches the artifact hash
-	err = verifyHashedMessages(ts.HashAlgorithm.New(), ts.HashedMessage, artifact)
-	if err != nil {
+	if err = verifyHashedMessages(ts.HashAlgorithm.New(), ts.HashedMessage, artifact); err != nil {
 		return nil, err
 	}
 

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -113,19 +113,26 @@ func TestVerifyArtifactHashedMessages(t *testing.T) {
 			Roots:         certs[2:],
 		}
 
-		if err := VerifyTimestampResponse(respBytes.Bytes(), strings.NewReader(tc.message), opts); err != nil {
-			t.Errorf("verifyHashedMessages failed comparing hashes: %v", err)
+		ts, err := VerifyTimestampResponse(respBytes.Bytes(), strings.NewReader(tc.message), opts)
+		if err != nil {
+			t.Errorf("VerifyTimestampResponse failed to verify the timestamp: %v", err)
+		}
+		if ts == nil {
+			t.Error("VerifyTimestampResponse did not return the parsed timestamp as expected")
 		}
 
 		if tc.forceError {
 			// Force hashed message error mismatch
 			msg := tc.message + "XXX"
-			err := VerifyTimestampResponse(respBytes.Bytes(), strings.NewReader(msg), opts)
+			ts, err := VerifyTimestampResponse(respBytes.Bytes(), strings.NewReader(msg), opts)
 			if err == nil {
 				t.Error("expected error message when verifying the timestamp response")
 			}
 			if err != nil && err.Error() != tc.expectedErrorMessage {
 				t.Errorf("expected error message when verifying the timestamp response: %s got %s", tc.expectedErrorMessage, err.Error())
+			}
+			if ts != nil {
+				t.Errorf("expected VerifyTimestampResponse to return a nil Timestamp object")
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Meredith Lancaster <malancas@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/timestamp-authority/issues/169

The `verify` CLI command now returns the parsed timestamp when verification is successful.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->