### PR TITLE
Reject requests that use SHA-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A service for issuing [RFC 3161 timestamps](https://datatracker.ietf.org/doc/html/rfc3161).
 
 Timestamps conform to the [RFC 3628 policy](https://datatracker.ietf.org/doc/html/rfc3628).
+The timestamp structure conforms to the updates in [RFC 5816](https://datatracker.ietf.org/doc/rfc5816).
 
 ## Security model
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	failedToGenerateTimestampResponse = "Error generating timestamp response"
+	weakHashAlgorithmTimestampRequest = "Weak hash algorithm in timestamp request"
 )
 
 func errorMsg(message string, code int) *models.Error {

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/digitorus/timestamp"
 	"github.com/go-openapi/runtime/middleware"
 	ts "github.com/sigstore/timestamp-authority/pkg/generated/restapi/operations/timestamp"
+	"github.com/sigstore/timestamp-authority/pkg/verification"
 )
 
 func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.Responder {
@@ -35,6 +36,10 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 	req, err := timestamp.ParseRequest(requestBytes)
 	if err != nil {
 		return handleTimestampAPIError(params, http.StatusBadRequest, err, failedToGenerateTimestampResponse)
+	}
+
+	if err := verification.VerifyRequest(req); err != nil {
+		return handleTimestampAPIError(params, http.StatusBadRequest, err, weakHashAlgorithmTimestampRequest)
 	}
 
 	policyID := req.TSAPolicyOID

--- a/pkg/verification/verify_request.go
+++ b/pkg/verification/verify_request.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verification
+
+import (
+	"crypto"
+
+	"github.com/digitorus/timestamp"
+	"github.com/pkg/errors"
+)
+
+func VerifyRequest(ts *timestamp.Request) error {
+	// only SHA-1, SHA-256, SHA-384, and SHA-512 are supported by the underlying library
+	if ts.HashAlgorithm == crypto.SHA1 {
+		return errors.New("weak hash algorithm: must be SHA-256, SHA-384, or SHA-512")
+	}
+	return nil
+}

--- a/pkg/verification/verify_request_test.go
+++ b/pkg/verification/verify_request_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verification
+
+import (
+	"crypto"
+	"strings"
+	"testing"
+
+	"github.com/digitorus/timestamp"
+)
+
+func TestVerifyRequest(t *testing.T) {
+	tsReq := &timestamp.Request{}
+
+	for _, alg := range []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512} {
+		tsReq.HashAlgorithm = alg
+		if err := VerifyRequest(tsReq); err != nil {
+			t.Fatalf("unexpected error verifying request, got %v", err)
+		}
+	}
+
+	tsReq.HashAlgorithm = crypto.SHA1
+	if err := VerifyRequest(tsReq); err == nil || !strings.Contains(err.Error(), "weak hash algorithm") {
+		t.Fatalf("expected error with weak hash algorithm, got %v", err)
+	}
+}

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -35,20 +34,13 @@ import (
 	"github.com/digitorus/timestamp"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/timestamp-authority/pkg/client"
+	"github.com/sigstore/timestamp-authority/pkg/client/mock"
 	tsatimestamp "github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
-	"github.com/sigstore/timestamp-authority/pkg/server"
 	"github.com/sigstore/timestamp-authority/pkg/signer"
-	"github.com/spf13/viper"
 )
 
 func TestVerifyArtifactHashedMessages(t *testing.T) {
-	viper.Set("timestamp-signer", "memory")
-	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
-	server := httptest.NewServer(apiServer.GetHandler())
-	t.Cleanup(server.Close)
-
-	c, err := client.GetTimestampClient(server.URL)
+	c, err := mock.NewTSAClient(mock.TSAClientOptions{Time: time.Now()})
 	if err != nil {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}


### PR DESCRIPTION
This is an outdated algorithm that should not be used.

Fixes #201

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->