### PR TITLE
Remove signer hardcoding of SHA-256

### DIFF
--- a/cmd/fetch-tsa-certs/fetch_tsa_certs.go
+++ b/cmd/fetch-tsa-certs/fetch_tsa_certs.go
@@ -50,12 +50,15 @@ import (
 To run:
 go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
   --intermediate-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>/versions/1" \
+  --intermediate-hash-function="sha256" \
   --leaf-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<leaf-key-ring>/cryptoKeys/<key>/versions/1" \
+  --leaf-hash-function="sha256" \
   --gcp-ca-parent="projects/<project>/locations/<region>/caPools/<ca-pool>" \
   --output="chain.crt.pem"
 
 go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
   --intermediate-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>/versions/1" \
+  --intermediate-hash-function="sha256" \
   --tink-kms-resource="gcp-kms://projects/<project>/locations/<region>/keyRings/<key-ring>/cryptoKeys/<key>" \
   --tink-keyset-path="enc-keyset.cfg" \
   --gcp-ca-parent="projects/<project>/locations/<region>/caPools/<ca-pool>" \

--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -66,6 +66,8 @@ func init() {
 	rootCmd.PersistentFlags().String("tink-hcvault-token", "", "Authentication token for Hashicorp Vault API calls")
 	// KMS, Tink and File flags
 	rootCmd.PersistentFlags().String("certificate-chain-path", "", "Path to PEM-encoded certificate chain certifying the kms-key-resource, tink-key-resource, or file-signer-key-path to act as a timestamping authority")
+	// KMS and memory flags
+	rootCmd.PersistentFlags().String("signer-hash-function", "", "Hash function used by the signer. Valid options include: [sha256, sha384, sha512]")
 	// File flags
 	rootCmd.PersistentFlags().String("file-signer-key-path", "", "Path to file containing PEM-encoded private key. Supported formats include PKCS#1, PKCS#8, and RFC5915 for EC")
 	rootCmd.PersistentFlags().String("file-signer-passwd", "", "Password to decrypt private key")

--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -66,7 +66,7 @@ func init() {
 	rootCmd.PersistentFlags().String("tink-hcvault-token", "", "Authentication token for Hashicorp Vault API calls")
 	// KMS, Tink and File flags
 	rootCmd.PersistentFlags().String("certificate-chain-path", "", "Path to PEM-encoded certificate chain certifying the kms-key-resource, tink-key-resource, or file-signer-key-path to act as a timestamping authority")
-	// KMS and memory flags
+	// KMS, File, and Memory flags
 	rootCmd.PersistentFlags().String("signer-hash-function", "", "Hash function used by the signer. Valid options include: [sha256, sha384, sha512]")
 	// File flags
 	rootCmd.PersistentFlags().String("file-signer-key-path", "", "Path to file containing PEM-encoded private key. Supported formats include PKCS#1, PKCS#8, and RFC5915 for EC")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       "--host=0.0.0.0",
       "--port=3000",
       "--timestamp-signer=memory",
+      "--signer-hash-function=sha256",
       # Uncomment this for production logging
       # "--log-type=prod",
       ]

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -46,7 +46,8 @@ func NewAPI() (*API, error) {
 		viper.GetString("kms-key-resource"),
 		viper.GetString("tink-key-resource"), viper.GetString("tink-keyset-path"),
 		viper.GetString("tink-hcvault-token"),
-		viper.GetString("file-signer-key-path"), viper.GetString("file-signer-passwd"))
+		viper.GetString("file-signer-key-path"), viper.GetString("file-signer-passwd"),
+		viper.GetString("signer-hash-function"))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting new tsa signer")
 	}

--- a/pkg/signer/file.go
+++ b/pkg/signer/file.go
@@ -30,7 +30,7 @@ type File struct {
 	crypto.Signer
 }
 
-func NewFileSigner(keyPath, keyPass string) (*File, error) {
+func NewFileSigner(keyPath, keyPass string, hashFunc crypto.Hash) (*File, error) {
 	opaqueKey, err := pemutil.Read(keyPath, pemutil.WithPassword([]byte(keyPass)))
 	if err != nil {
 		return nil, fmt.Errorf("file: provide a valid signer, %s is not valid: %w", keyPath, err)
@@ -38,18 +38,21 @@ func NewFileSigner(keyPath, keyPass string) (*File, error) {
 	// Cannot use signature.LoadSignerVerifier because the SignerVerifier interface does not extend crypto.Signer
 	switch pk := opaqueKey.(type) {
 	case *rsa.PrivateKey:
-		signer, err := signature.LoadRSAPKCS1v15SignerVerifier(pk, crypto.SHA256)
+		signer, err := signature.LoadRSAPKCS1v15SignerVerifier(pk, hashFunc)
 		if err != nil {
 			return nil, err
 		}
 		return &File{signer}, nil
 	case *ecdsa.PrivateKey:
-		signer, err := signature.LoadECDSASignerVerifier(pk, crypto.SHA256)
+		signer, err := signature.LoadECDSASignerVerifier(pk, hashFunc)
 		if err != nil {
 			return nil, err
 		}
 		return &File{signer}, nil
 	case ed25519.PrivateKey:
+		if hashFunc != crypto.SHA512 {
+			fmt.Printf("ed25519 only supports SHA512, specified hash func is %s. Using SHA512\n", hashFunc)
+		}
 		signer, err := signature.LoadED25519SignerVerifier(pk)
 		if err != nil {
 			return nil, err

--- a/pkg/signer/file.go
+++ b/pkg/signer/file.go
@@ -51,7 +51,7 @@ func NewFileSigner(keyPath, keyPass string, hashFunc crypto.Hash) (*File, error)
 		return &File{signer}, nil
 	case ed25519.PrivateKey:
 		if hashFunc != crypto.SHA512 {
-			fmt.Printf("ed25519 only supports SHA512, specified hash func is %s. Using SHA512\n", hashFunc)
+			fmt.Printf("Ed25519 only supports SHA512, specified hash func is %s. Using hash function specified by Ed25519\n", hashFunc)
 		}
 		signer, err := signature.LoadED25519SignerVerifier(pk)
 		if err != nil {

--- a/pkg/signer/file_test.go
+++ b/pkg/signer/file_test.go
@@ -15,6 +15,7 @@
 package signer
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -88,7 +89,7 @@ func TestNewFileSigner(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-			_, err := NewFileSigner(tc.keyPath, tc.keyPass)
+			_, err := NewFileSigner(tc.keyPath, tc.keyPass, crypto.SHA384)
 			if tc.wantErr != (err != nil) {
 				t.Errorf("NewFileSigner() expected %t, got err %s", tc.wantErr, err)
 			}

--- a/pkg/signer/memory.go
+++ b/pkg/signer/memory.go
@@ -34,7 +34,7 @@ func getCurveFromSigner(signer crypto.Signer) (elliptic.Curve, error) {
 	// the in-memory cert chain uses ECDSA keys, so we cast the public key to an ECDSA key
 	pub, ok := signer.Public().(*ecdsa.PublicKey)
 	if !ok {
-		return nil, errors.New("signer is not an ECDSA key")
+		return nil, errors.New("casting signer's public key to an ECDSA key")
 	}
 	return pub.Curve, nil
 }

--- a/pkg/signer/memory_test.go
+++ b/pkg/signer/memory_test.go
@@ -30,7 +30,7 @@ import (
 func TestNewTimestampingCertWithChain(t *testing.T) {
 	ctx := context.Background()
 
-	signer, err := NewCryptoSigner(ctx, "memory", "", "", "", "", "", "")
+	signer, err := NewCryptoSigner(ctx, "memory", "", "", "", "", "", "", "sha256")
 	if err != nil {
 		t.Fatalf("new signer: %v", err)
 	}

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -59,7 +59,11 @@ func NewCryptoSigner(ctx context.Context, signer, kmsKey, tinkKmsKey, tinkKeyset
 		sv, _, err := signature.NewECDSASignerVerifier(curve, rand.Reader, hashFunc)
 		return sv, err
 	case FileScheme:
-		return NewFileSigner(fileSignerPath, fileSignerPasswd)
+		hashFunc, _, err := getHashFuncEllipticCurve(signerHashFunc)
+		if err != nil {
+			return nil, err
+		}
+		return NewFileSigner(fileSignerPath, fileSignerPasswd, hashFunc)
 	case KMSScheme:
 		hashFunc, _, err := getHashFuncEllipticCurve(signerHashFunc)
 		if err != nil {
@@ -76,7 +80,11 @@ func NewCryptoSigner(ctx context.Context, signer, kmsKey, tinkKmsKey, tinkKeyset
 		if err != nil {
 			return nil, err
 		}
-		return NewTinkSigner(ctx, tinkKeysetPath, primaryKey)
+		hashFunc, _, err := getHashFuncEllipticCurve(signerHashFunc)
+		if err != nil {
+			return nil, err
+		}
+		return NewTinkSigner(ctx, tinkKeysetPath, primaryKey, hashFunc)
 	default:
 		return nil, fmt.Errorf("unsupported signer type: %s", signer)
 	}

--- a/pkg/signer/signer_test.go
+++ b/pkg/signer/signer_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package signer
 
 import (

--- a/pkg/signer/signer_test.go
+++ b/pkg/signer/signer_test.go
@@ -1,0 +1,51 @@
+package signer
+
+import (
+	"context"
+	"testing"
+)
+
+type testcase struct {
+	name             string
+	signerHashFunc   string
+	expectTestToPass bool
+}
+
+func TestNewCryptoSignerSignerHashFunc(t *testing.T) {
+	testcases := []testcase{{
+		name:             "SHA256",
+		signerHashFunc:   "sha256",
+		expectTestToPass: true,
+	},
+		{
+			name:             "SHA384",
+			signerHashFunc:   "sha384",
+			expectTestToPass: true,
+		},
+		{
+			name:             "SHA512",
+			signerHashFunc:   "sha512",
+			expectTestToPass: true,
+		},
+		{
+			name:             "Empty hash func",
+			signerHashFunc:   "",
+			expectTestToPass: false,
+		},
+		{
+			name:             "Unsupported hash func",
+			signerHashFunc:   "sha224",
+			expectTestToPass: false,
+		}}
+
+	for _, tc := range testcases {
+		_, err := NewCryptoSigner(context.Background(), "memory", "", "", "", "", "", "", tc.signerHashFunc)
+		if err != nil && tc.expectTestToPass {
+			t.Fatalf("test case '%s' failed: %v", tc.name, err)
+		}
+
+		if err == nil && !tc.expectTestToPass {
+			t.Fatalf("test case '%s' failed: expected error but got nil", tc.name)
+		}
+	}
+}

--- a/pkg/signer/tink.go
+++ b/pkg/signer/tink.go
@@ -130,7 +130,7 @@ func KeyHandleToSigner(kh *keyset.Handle, hashFunc crypto.Hash) (crypto.Signer, 
 		return p, nil
 	case ed25519SignerTypeURL:
 		if hashFunc != crypto.SHA512 {
-			fmt.Printf("ed25519 only supports SHA512, specified hash func is %s. Using SHA512\n", hashFunc)
+			fmt.Printf("Ed25519 only supports SHA512, specified hash func is %s. Using hash function specified by Ed25519\n", hashFunc)
 		}
 		// https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ed25519_signer_key_manager.go#L47
 		privKey := new(ed25519pb.Ed25519PrivateKey)

--- a/pkg/signer/tink_test.go
+++ b/pkg/signer/tink_test.go
@@ -16,6 +16,7 @@ package signer
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -53,7 +54,7 @@ func TestNewTinkSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating ECDSA key handle: %v", err)
 	}
-	khsigner, err := KeyHandleToSigner(kh)
+	khsigner, err := KeyHandleToSigner(kh, crypto.SHA512)
 	if err != nil {
 		t.Fatalf("error converting ECDSA key handle to signer: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestNewTinkSigner(t *testing.T) {
 		t.Fatalf("error writing enc keyset: %v", err)
 	}
 
-	signer, err := NewTinkSigner(context.TODO(), keysetPath, a)
+	signer, err := NewTinkSigner(context.TODO(), keysetPath, a, crypto.SHA512)
 	if err != nil {
 		t.Fatalf("unexpected error creating Tink signer: %v", err)
 	}
@@ -89,7 +90,7 @@ func TestNewTinkSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating AEAD key: %v", err)
 	}
-	_, err = NewTinkSigner(context.TODO(), keysetPath, a1)
+	_, err = NewTinkSigner(context.TODO(), keysetPath, a1, crypto.SHA512)
 	if err == nil || !strings.Contains(err.Error(), "decryption failed") {
 		t.Fatalf("expected error decrypting keyset, got %v", err)
 	}
@@ -116,7 +117,7 @@ func TestKeyHandleToSignerECDSA(t *testing.T) {
 			t.Fatalf("error creating ECDSA key handle: %v", err)
 		}
 		// convert to crypto.Signer interface
-		signer, err := KeyHandleToSigner(kh)
+		signer, err := KeyHandleToSigner(kh, crypto.SHA512)
 		if err != nil {
 			t.Fatalf("error converting ECDSA key handle to signer: %v", err)
 		}
@@ -162,7 +163,7 @@ func TestKeyHandleToSignerED25519(t *testing.T) {
 		t.Fatalf("error creating ED25519 key handle: %v", err)
 	}
 	// convert to crypto.Signer interface
-	signer, err := KeyHandleToSigner(kh)
+	signer, err := KeyHandleToSigner(kh, crypto.SHA512)
 	if err != nil {
 		t.Fatalf("error converting ED25519 key handle to signer: %v", err)
 	}

--- a/pkg/tests/server.go
+++ b/pkg/tests/server.go
@@ -28,6 +28,7 @@ import (
 
 func createServer(t *testing.T) string {
 	viper.Set("timestamp-signer", "memory")
+	viper.Set("signer-hash-function", "sha256")
 	// unused port
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/timestamp-authority/issues/304

Currently when signers are created, SHA-256 is always used. A KMS based key may use a different supported algorithm, like SHA-384 or SHA-512, so this hardcoding should be removed.

- Adds a new timestamp-server flag `signer-hash-function` that allows the user to specify a signer hash function. This is used in several different signer schemes
- Adds two new fetch-tsa-certs flags, `intermediate-hash-function` and `leaf-hash-function`, that allow the user to specify the leaf and intermediate key hash functions
- Updates the signer code to handle a specified hash function

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
