### PR TITLE
fix 'certficate' typo, regen files

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,8 +57,8 @@ paths:
 
   /api/v1/timestamp/certchain:
     get:
-      summary: Retrieve the certficate chain for timestamping that can be used to validate trusted timestamps
-      description: Returns the certficate chain for timestamping that can be used to validate trusted timestamps
+      summary: Retrieve the certificate chain for timestamping that can be used to validate trusted timestamps
+      description: Returns the certificate chain for timestamping that can be used to validate trusted timestamps
       operationId: getTimestampCertChain
       tags:
         - timestamp

--- a/pkg/generated/client/timestamp/timestamp_client.go
+++ b/pkg/generated/client/timestamp/timestamp_client.go
@@ -53,9 +53,9 @@ type ClientService interface {
 }
 
 /*
-GetTimestampCertChain retrieves the certficate chain for timestamping that can be used to validate trusted timestamps
+GetTimestampCertChain retrieves the certificate chain for timestamping that can be used to validate trusted timestamps
 
-Returns the certficate chain for timestamping that can be used to validate trusted timestamps
+Returns the certificate chain for timestamping that can be used to validate trusted timestamps
 */
 func (a *Client) GetTimestampCertChain(params *GetTimestampCertChainParams, opts ...ClientOption) (*GetTimestampCertChainOK, error) {
 	// TODO: Validate the params before sending

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -91,7 +91,7 @@ func init() {
     },
     "/api/v1/timestamp/certchain": {
       "get": {
-        "description": "Returns the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "description": "Returns the certificate chain for timestamping that can be used to validate trusted timestamps",
         "consumes": [
           "application/json"
         ],
@@ -101,7 +101,7 @@ func init() {
         "tags": [
           "timestamp"
         ],
-        "summary": "Retrieve the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "summary": "Retrieve the certificate chain for timestamping that can be used to validate trusted timestamps",
         "operationId": "getTimestampCertChain",
         "responses": {
           "200": {
@@ -219,7 +219,7 @@ func init() {
     },
     "/api/v1/timestamp/certchain": {
       "get": {
-        "description": "Returns the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "description": "Returns the certificate chain for timestamping that can be used to validate trusted timestamps",
         "consumes": [
           "application/json"
         ],
@@ -229,7 +229,7 @@ func init() {
         "tags": [
           "timestamp"
         ],
-        "summary": "Retrieve the certficate chain for timestamping that can be used to validate trusted timestamps",
+        "summary": "Retrieve the certificate chain for timestamping that can be used to validate trusted timestamps",
         "operationId": "getTimestampCertChain",
         "responses": {
           "200": {

--- a/pkg/generated/restapi/operations/timestamp/get_timestamp_cert_chain.go
+++ b/pkg/generated/restapi/operations/timestamp/get_timestamp_cert_chain.go
@@ -47,9 +47,9 @@ func NewGetTimestampCertChain(ctx *middleware.Context, handler GetTimestampCertC
 /*
 	GetTimestampCertChain swagger:route GET /api/v1/timestamp/certchain timestamp getTimestampCertChain
 
-# Retrieve the certficate chain for timestamping that can be used to validate trusted timestamps
+# Retrieve the certificate chain for timestamping that can be used to validate trusted timestamps
 
-Returns the certficate chain for timestamping that can be used to validate trusted timestamps
+Returns the certificate chain for timestamping that can be used to validate trusted timestamps
 */
 type GetTimestampCertChain struct {
 	Context *middleware.Context

--- a/pkg/generated/restapi/operations/timestamp_server_api.go
+++ b/pkg/generated/restapi/operations/timestamp_server_api.go
@@ -350,6 +350,6 @@ func (o *TimestampServerAPI) AddMiddlewareFor(method, path string, builder middl
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }


### PR DESCRIPTION
#### Summary
fixed a minor typo (`certficate` with missing `i`), regenerated the files

#### Release Note
NONE

#### Documentation
not required
