### PR TITLE
Fix bug where TSA signing fails if cert hash != content hash.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/security v1.15.1
 	github.com/beevik/ntp v1.3.0
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352
-	github.com/digitorus/timestamp v0.0.0-20230821155606-d1ad5ca9624c
+	github.com/digitorus/timestamp v0.0.0-20230902153158-687734543647
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/loads v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
 github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 h1:ge14PCmCvPjpMQMIAH7uKg0lrtNSOdpYsRXlwk3QbaE=
 github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
-github.com/digitorus/timestamp v0.0.0-20230821155606-d1ad5ca9624c h1:kgG83Hfj3YXkUbrihwBxDc0COzP1ZejiDSr4/fItT0E=
-github.com/digitorus/timestamp v0.0.0-20230821155606-d1ad5ca9624c/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
+github.com/digitorus/timestamp v0.0.0-20230902153158-687734543647 h1:WOk5Aclr/+sZ2/SX2YyxulNFwZOUhSrDJLw5KbHKmdE=
+github.com/digitorus/timestamp v0.0.0-20230902153158-687734543647/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -173,7 +173,7 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 		ExtraExtensions:   req.Extensions,
 	}
 
-	resp, err := tsStruct.CreateResponse(api.certChain[0], api.tsaSigner)
+	resp, err := tsStruct.CreateResponseWithOpts(api.certChain[0], api.tsaSigner, crypto.SHA256)
 	if err != nil {
 		return handleTimestampAPIError(params, http.StatusInternalServerError, err, failedToGenerateTimestampResponse)
 	}

--- a/pkg/client/mock/mock_tsa_client.go
+++ b/pkg/client/mock/mock_tsa_client.go
@@ -137,7 +137,7 @@ func (c *TSAClient) GetTimestampResponse(params *ts.GetTimestampResponseParams, 
 		tsStruct.Time = c.Time
 	}
 
-	resp, err := tsStruct.CreateResponse(c.CertChain[0], c.Signer)
+	resp, err := tsStruct.CreateResponseWithOpts(c.CertChain[0], c.Signer, crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -510,7 +510,7 @@ func createSignedTimestamp(certChain []*x509.Certificate, sv *signature.ECDSASig
 		ExtraExtensions:   req.Extensions,
 	}
 
-	resp, err := tsTemplate.CreateResponse(certChain[0], sv)
+	resp, err := tsTemplate.CreateResponseWithOpts(certChain[0], sv, crypto.SHA256)
 	if err != nil {
 		return nil, fmt.Errorf("unexpectedly failed to create timestamp response: %v", err)
 	}


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This was fixed upstream in https://github.com/digitorus/timestamp/pull/19.

We should cut a patch release - the buggy behavior was introduced in v1.1.2.

NOTE: This potentially breaks some users if they are relying on the new cert hash behavior introduced in v1.1.2 to support other hash types (since this defaults back to sha256), but this fixes those who were broken by the v1.1.2 update. Support for other hash types can be added in another PR by moving to using [timestamp.CreateResponseWithOpts](https://pkg.go.dev/github.com/digitorus/timestamp#Timestamp.CreateResponseWithOpts) and passing in the appropriate hash (but I'm considering that out of scope for this PR).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Fixes bug where signing fails if content hash != cert hash.
- BREAKING CHANGE: This reverts a new addition made in v1.1.2 that let some users use other content hashes under certain conditions but broke other users. This change reverts content hash behavior back to sha256 for the time being.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

I don't think we have a good spot for this at the moment? Happy to add some if you point me to the right place.