### PR TITLE
new http-ping-only flag for 'timestamp-server serve'

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -26,9 +26,10 @@ import (
 )
 
 var (
-	cfgFile     string
-	logType     string
-	enablePprof bool
+	cfgFile      string
+	logType      string
+	enablePprof  bool
+	httpPingOnly bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -56,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.timestamp-server.yaml)")
 	rootCmd.PersistentFlags().StringVar(&logType, "log-type", "dev", "logger type to use (dev/prod)")
 	rootCmd.PersistentFlags().BoolVar(&enablePprof, "enable-pprof", false, "enable pprof for profiling on port 6060")
-
+	rootCmd.PersistentFlags().BoolVar(&httpPingOnly, "http-ping-only", false, "serve only /ping in the http server")
 	rootCmd.PersistentFlags().String("timestamp-signer", "memory", "Timestamping authority signer. Valid options include: [kms, tink, memory, file]. Memory and file-based signers should only be used for testing")
 	// KMS flags
 	rootCmd.PersistentFlags().String("kms-key-resource", "", "KMS key for signing timestamp responses. Valid options include: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource]")

--- a/cmd/timestamp-server/app/serve.go
+++ b/cmd/timestamp-server/app/serve.go
@@ -100,8 +100,8 @@ var serveCmd = &cobra.Command{
 		host := viper.GetString("host")
 		port := int(viper.GetUint("port"))
 		scheme := viper.GetStringSlice("scheme")
-
-		server := server.NewRestAPIServer(host, port, scheme, readTimeout, writeTimeout)
+		httpPingOnly := viper.GetBool("http-ping-only")
+		server := server.NewRestAPIServer(host, port, scheme, httpPingOnly, readTimeout, writeTimeout)
 		defer func() {
 			if err := server.Shutdown(); err != nil {
 				log.Logger.Error(err)

--- a/cmd/timestamp-server/app/serve.go
+++ b/cmd/timestamp-server/app/serve.go
@@ -100,7 +100,6 @@ var serveCmd = &cobra.Command{
 		host := viper.GetString("host")
 		port := int(viper.GetUint("port"))
 		scheme := viper.GetStringSlice("scheme")
-		httpPingOnly := viper.GetBool("http-ping-only")
 		server := server.NewRestAPIServer(host, port, scheme, httpPingOnly, readTimeout, writeTimeout)
 		defer func() {
 			if err := server.Shutdown(); err != nil {

--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -110,7 +110,7 @@ func httpPingOnly(endpoint string) func(http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Scheme != "https" && !strings.EqualFold(r.URL.Path, endpoint) {
 				w.Header().Set("Content-Type", "text/plain")
-				w.WriteHeader(http.StatusForbidden)
+				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte("http server supports only the /ping entrypoint")) //nolint:errcheck
 				return
 			}

--- a/pkg/internal/cmdparams/cmdparams.go
+++ b/pkg/internal/cmdparams/cmdparams.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Sigstore Authors.
+// Copyright 2023 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/internal/cmdparams/cmdparams.go
+++ b/pkg/internal/cmdparams/cmdparams.go
@@ -1,0 +1,23 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdparams
+
+// IsHTTPPingOnly is set off the command-line flag to enforce limiting
+// the non-mTLS http server to only serving the /ping entrypoint.
+// It should be set only once when processing command-line flags
+// and then used only in pkg/generated/restapi/configure_timestamp_server.go
+// and as read-only.
+var IsHTTPPingOnly bool

--- a/pkg/internal/cmdparams/doc.go
+++ b/pkg/internal/cmdparams/doc.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 The Sigstore Authors.
+// Copyright 2023 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/internal/cmdparams/doc.go
+++ b/pkg/internal/cmdparams/doc.go
@@ -1,0 +1,19 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmdparams contains variables to propagate from command-line
+// flags to their handling in
+// pkg/generated/restapi/configure_timestamp_server.go.
+package cmdparams

--- a/pkg/ntpmonitor/config.go
+++ b/pkg/ntpmonitor/config.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/server/restapi.go
+++ b/pkg/server/restapi.go
@@ -21,10 +21,15 @@ import (
 	"github.com/sigstore/timestamp-authority/pkg/api"
 	"github.com/sigstore/timestamp-authority/pkg/generated/restapi"
 	"github.com/sigstore/timestamp-authority/pkg/generated/restapi/operations"
+	"github.com/sigstore/timestamp-authority/pkg/internal/cmdparams"
 )
 
 // NewRestAPIServer creates a server for serving the rest API TSA service
-func NewRestAPIServer(host string, port int, scheme []string, readTimeout, writeTimeout time.Duration) *restapi.Server {
+func NewRestAPIServer(host string,
+	port int,
+	scheme []string,
+	httpReadOnly bool,
+	readTimeout, writeTimeout time.Duration) *restapi.Server {
 	doc, _ := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	server := restapi.NewServer(operations.NewTimestampServerAPI(doc))
 
@@ -33,7 +38,7 @@ func NewRestAPIServer(host string, port int, scheme []string, readTimeout, write
 	server.EnabledListeners = scheme
 	server.ReadTimeout = readTimeout
 	server.WriteTimeout = writeTimeout
-
+	cmdparams.IsHTTPPingOnly = httpReadOnly
 	api.ConfigureAPI()
 	server.ConfigureAPI()
 

--- a/pkg/tests/server.go
+++ b/pkg/tests/server.go
@@ -29,7 +29,7 @@ import (
 func createServer(t *testing.T) string {
 	viper.Set("timestamp-signer", "memory")
 	// unused port
-	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
+	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, false, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())
 	t.Cleanup(server.Close)
 


### PR DESCRIPTION
#### Summary
The change adds a new command-line flag for the `timestamp-server serve` command to address the following need:
* must serve timestamp requests only via the https server with mTLS
* need to provide the ability to do ping-like checks over http server (for the load balancers that don't have access to the mTLS credentials)

The solution is to add the `--http-ping-only` boolean flag (default `false`) that when given, restricts the http server to serve only the (existing) `/ping` entrypoint - for others, the http server responds with '400 Forbidden' and a short message.

Since I could find no other alternative (despite asking in different forums/channels) in the swagger generation framework, I resorted to created a boolean global variable `IsHTTPPingOnly` in the new pkg/internal/cmdparams subpackage to pass the flag values to the server implementation in `pkg/generated/restapi/configure_timestamp_server.go`.  If you can suggest a more elegant way to achieve the same goal, please let me know.

Related to https://github.com/sigstore/timestamp-authority/issues/420.

#### Release Note
* New features and improvements, including behavioural changes, UI changes and CLI changes
added the optional `--http-ping-only` boolean flag to restrict the http server to the `/ping` entrypoint.

#### Documentation
option is documented in the output of `timestamp-server serve --help`:
```
$ timestamp-server serve --help
Starts a http server and serves the configured api

Usage:
  timestamp-server serve [flags]
[...]
      --http-ping-only                  serve only /ping in the http server
```
