### PR TITLE
Support other hash algs for pre-signed timestamp besides SHA256

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -59,6 +59,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enablePprof, "enable-pprof", false, "enable pprof for profiling on port 6060")
 	rootCmd.PersistentFlags().BoolVar(&httpPingOnly, "http-ping-only", false, "serve only /ping in the http server")
 	rootCmd.PersistentFlags().String("timestamp-signer", "memory", "Timestamping authority signer. Valid options include: [kms, tink, memory, file]. Memory and file-based signers should only be used for testing")
+	rootCmd.PersistentFlags().String("timestamp-signer-hash", "sha256", "Hash algorithm used by the signer. Must match the hash algorithm specified for a KMS or Tink key. Valid options include: [sha256, sha384, sha512]. Ignored for Memory signer.")
 	// KMS flags
 	rootCmd.PersistentFlags().String("kms-key-resource", "", "KMS key for signing timestamp responses. Valid options include: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource]")
 	// Tink flags

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -173,7 +173,7 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 		ExtraExtensions:   req.Extensions,
 	}
 
-	resp, err := tsStruct.CreateResponseWithOpts(api.certChain[0], api.tsaSigner, crypto.SHA256)
+	resp, err := tsStruct.CreateResponseWithOpts(api.certChain[0], api.tsaSigner, api.tsaSignerHash)
 	if err != nil {
 		return handleTimestampAPIError(params, http.StatusInternalServerError, err, failedToGenerateTimestampResponse)
 	}

--- a/pkg/signer/file.go
+++ b/pkg/signer/file.go
@@ -30,7 +30,7 @@ type File struct {
 	crypto.Signer
 }
 
-func NewFileSigner(keyPath, keyPass string) (*File, error) {
+func NewFileSigner(keyPath, keyPass string, hash crypto.Hash) (*File, error) {
 	opaqueKey, err := pemutil.Read(keyPath, pemutil.WithPassword([]byte(keyPass)))
 	if err != nil {
 		return nil, fmt.Errorf("file: provide a valid signer, %s is not valid: %w", keyPath, err)
@@ -38,13 +38,13 @@ func NewFileSigner(keyPath, keyPass string) (*File, error) {
 	// Cannot use signature.LoadSignerVerifier because the SignerVerifier interface does not extend crypto.Signer
 	switch pk := opaqueKey.(type) {
 	case *rsa.PrivateKey:
-		signer, err := signature.LoadRSAPKCS1v15SignerVerifier(pk, crypto.SHA256)
+		signer, err := signature.LoadRSAPKCS1v15SignerVerifier(pk, hash)
 		if err != nil {
 			return nil, err
 		}
 		return &File{signer}, nil
 	case *ecdsa.PrivateKey:
-		signer, err := signature.LoadECDSASignerVerifier(pk, crypto.SHA256)
+		signer, err := signature.LoadECDSASignerVerifier(pk, hash)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/signer/file_test.go
+++ b/pkg/signer/file_test.go
@@ -15,6 +15,7 @@
 package signer
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -88,7 +89,7 @@ func TestNewFileSigner(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-			_, err := NewFileSigner(tc.keyPath, tc.keyPass)
+			_, err := NewFileSigner(tc.keyPath, tc.keyPass, crypto.SHA256)
 			if tc.wantErr != (err != nil) {
 				t.Errorf("NewFileSigner() expected %t, got err %s", tc.wantErr, err)
 			}

--- a/pkg/signer/memory_test.go
+++ b/pkg/signer/memory_test.go
@@ -30,7 +30,7 @@ import (
 func TestNewTimestampingCertWithChain(t *testing.T) {
 	ctx := context.Background()
 
-	signer, err := NewCryptoSigner(ctx, "memory", "", "", "", "", "", "")
+	signer, err := NewCryptoSigner(ctx, crypto.Hash(0), "memory", "", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("new signer: %v", err)
 	}

--- a/pkg/tests/server.go
+++ b/pkg/tests/server.go
@@ -28,6 +28,7 @@ import (
 
 func createServer(t *testing.T) string {
 	viper.Set("timestamp-signer", "memory")
+	viper.Set("timestamp-signer-hash", "sha256")
 	// unused port
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, false, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())


### PR DESCRIPTION
There are three relevant hash algs used in this codebase:

* The certificate hash alg, which specifies how the CA certificate hashed the to-be-signed certificate
* The message hash alg, specified in the request, which says how the timestamp message was hashed
* The timestamp hash alg, which specifies how the timestamp signer should hash the pre-signed timestamp structure

The latter of these three was not configurable. We had a previous approach that used the certificate hash alg, but this does not have to match the timestamp hash alg.

Fixes https://github.com/sigstore/timestamp-authority/issues/304

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
