### PR TITLE
Don't mark hash argument as required.

### DIFF
--- a/cmd/timestamp-cli/app/timestamp.go
+++ b/cmd/timestamp-cli/app/timestamp.go
@@ -41,7 +41,6 @@ func addTimestampFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(NewFlagValue(fileFlag, ""), "artifact", "path to an artifact to timestamp")
 	cmd.MarkFlagRequired("artifact") //nolint:errcheck
 	cmd.Flags().String("hash", "sha256", "hash algorithm to use - Valid values are sha256, sha384, and sha512")
-	cmd.MarkFlagRequired("hash") //nolint:errcheck
 	cmd.Flags().Bool("nonce", true, "specify a pseudo-random nonce in the request")
 	cmd.Flags().Bool("certificate", true, "if the timestamp response should contain a certificate chain")
 	cmd.Flags().Var(NewFlagValue(oidFlag, ""), "tsa-policy", "optional dotted OID notation for the policy that the TSA should use to create the response")


### PR DESCRIPTION

#### Summary
The hash hash argument a default value, which is documented. The mark required call broke this as it forces the caller to actually provide the hash algorithm

#### Release Note
* `--hash` argument to the `timestamp-cli timestamp` command is now optional as the documentation explains

#### Documentation
n/a
