### PR TITLE
chore: bump go to use v1.23

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,5 +95,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.58
+          version: v1.61
           args: --timeout=10m --verbose

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sigstore/timestamp-authority
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.23.1
 
 require (
 	cloud.google.com/go/security v1.17.4

--- a/pkg/signer/tink.go
+++ b/pkg/signer/tink.go
@@ -158,7 +158,7 @@ func getPrimaryKey(ks *tinkpb.Keyset) *tinkpb.KeyData {
 // validateEcdsaPrivKey validates the given ECDSAPrivateKey.
 // https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ecdsa_signer_key_manager.go#L139
 func validateEcdsaPrivKey(key *ecdsapb.EcdsaPrivateKey) error {
-	if err := keyset.ValidateKeyVersion(key.Version, uint32(ecdsaSignerKeyVersion)); err != nil {
+	if err := keyset.ValidateKeyVersion(key.Version, uint32(ecdsaSignerKeyVersion)); err != nil { //nolint:gosec
 		return fmt.Errorf("ecdsa_signer_key_manager: invalid key: %w", err)
 	}
 	hash, curve, encoding := getECDSAParamNames(key.PublicKey.Params)
@@ -178,7 +178,7 @@ func getECDSAParamNames(params *ecdsapb.EcdsaParams) (string, string, string) {
 // validateEd25519PrivKey validates the given ED25519PrivateKey.
 // https://github.com/google/tink/blob/9753ffddd4d04aa56e0605ff4a0db46f2fb80529/go/signature/ed25519_signer_key_manager.go#L132
 func validateEd25519PrivKey(key *ed25519pb.Ed25519PrivateKey) error {
-	if err := keyset.ValidateKeyVersion(key.Version, uint32(ed25519SignerKeyVersion)); err != nil {
+	if err := keyset.ValidateKeyVersion(key.Version, uint32(ed25519SignerKeyVersion)); err != nil { //nolint:gosec
 		return fmt.Errorf("ed25519_signer_key_manager: invalid key: %w", err)
 	}
 	if len(key.KeyValue) != ed25519.SeedSize {

--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -250,7 +250,7 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) error {
 		return fmt.Errorf("error parsing hashed message: %w", err)
 	}
 
-	if opts.Roots == nil || len(opts.Roots) == 0 {
+	if len(opts.Roots) == 0 {
 		return fmt.Errorf("no root certificates provided for verifying the certificate chain")
 	}
 


### PR DESCRIPTION
I am bumping our go version to use 1.23 so we can solve some CVEs and upgrade our go version to latest.