### PR TITLE
Fixes #846

### DIFF
--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -166,11 +166,11 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 		// states that the GeneralizedTime values MUST be expressed in Greenwich Mean Time.
 		// However, go asn1/marshal will happily accept other formats. So we force it directly here.
 		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5.2
-		Time:          time.Now().UTC(),
-		Nonce:         req.Nonce,
-		Policy:        policyID,
-		Ordering:      false,
-		Accuracy:      duration,
+		Time:     time.Now().UTC(),
+		Nonce:    req.Nonce,
+		Policy:   policyID,
+		Ordering: false,
+		Accuracy: duration,
 		// Not qualified for the european directive
 		Qualified:         false,
 		AddTSACertificate: req.Certificates,

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -162,7 +162,11 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 	tsStruct := timestamp.Timestamp{
 		HashAlgorithm: req.HashAlgorithm,
 		HashedMessage: req.HashedMessage,
-		Time:          time.Now(),
+		// The field here is going to be serialized as a GeneralizedTime, and RFC5280
+		// states that the GeneralizedTime values MUST be expressed in Greenwich Mean Time.
+		// However, go asn1/marshal will happily accept other formats. So we force it directly here.
+		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5.2
+		Time:          time.Now().UTC(),
 		Nonce:         req.Nonce,
 		Policy:        policyID,
 		Ordering:      false,

--- a/pkg/tests/api_test.go
+++ b/pkg/tests/api_test.go
@@ -166,6 +166,9 @@ func TestGetTimestampResponse(t *testing.T) {
 		if tsr.Time.After(time.Now()) {
 			t.Fatalf("test '%s': expected time to be set to a previous time", tc.name)
 		}
+		if tsr.Time.Location() != time.UTC {
+			t.Fatalf("test '%s': expected time to be in UTC, got %v", tc.name, tsr.Time.Location())
+		}
 		duration, _ := time.ParseDuration("1s")
 		if tsr.Accuracy != duration {
 			t.Fatalf("test '%s': expected 1s accuracy, got %v", tc.name, tsr.Accuracy)


### PR DESCRIPTION
#### Summary

This PR fixes the problem highlighted in #846 .

#### Release Note

FIX TimestampResponse Time were not properly returned as GMT.

#### Documentation

None