### PR TITLE
Compose quality-of-life improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
 services:
   timestamp-server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,17 +21,17 @@ services:
       "timestamp-server",
       "serve",
       "--host=0.0.0.0",
-      "--port=3000",
+      "--port=3004",
       "--timestamp-signer=memory",
       # Uncomment this for production logging
       # "--log-type=prod",
       ]
     restart: always # keep the server running
     ports:
-      - "3000:3000"
-      - "2112:2112"
+      - "3004:3004"
+      - "2115:2112"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:3004/ping"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
* don't use deprecated version field
* avoid using the same ports as the compose files of other main sigstore services: this makes it a little easier to start dev  containers of the main services