### PR TITLE
Fix --http-ping-only flag to not affect https listener

### DIFF
--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -110,7 +110,7 @@ const pingPath = "/ping"
 func httpPingOnly() func(http.Handler) http.Handler {
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Scheme != "https" && !strings.EqualFold(r.URL.Path, pingPath) {
+			if r.TLS == nil && !strings.EqualFold(r.URL.Path, pingPath) {
 				w.Header().Set("Content-Type", "text/plain")
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte("http server supports only the " + pingPath + " entrypoint")) //nolint:errcheck


### PR DESCRIPTION
#### Summary
When https scheme is enabled together with --http-ping-only it breaks the serving API (returns 404 for anything that's not /ping). This is due to the fact that r.URL.Scheme is not always populated, see similar issue [here](https://github.com/golang/go/issues/28940)

#### How to reproduce 
Start serving with both http and https schemes
Before
```
$ ./bin/timestamp-server serve --scheme http --port 8080 --http-ping-only --tls-port 8443  --scheme https --tls-certificate server.crt --tls-key server.key

$ curl localhost:8080/api/v1/timestamp
http server supports only the /ping entrypoint

$ curl https://localhost:8443/api/v1/timestamp -k
http server supports only the /ping entrypoint
```

After
```
$ curl localhost:8080/api/v1/timestamp
http server supports only the /ping entrypoint

curl https://localhost:8443/api/v1/timestamp -k
{"code":405,"message":"method GET is not allowed, but [POST] are"}
```

