### PR TITLE
fetch-tsa-certs: Add "--org-name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ used to generate the certificate chain if you do not want to use GCP.
       --leaf-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<timestamp-key>/versions/1" \
       --parent-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<intermediate-key>/versions/1" \
       --gcp-ca-parent="projects/<project>/locations/<region>/caPools/<ca-pool>" \
+      --org-name="example.com"
       --output="chain.crt.pem"
     ```
 
@@ -164,6 +165,7 @@ used to generate the certificate chain if you do not want to use GCP.
       --leaf-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<timestamp-key>/versions/1" \
       --parent-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<parent-key>/versions/1" \
       --parent-validity=<DAYS>
+      --org-name="example.com"
       --output="chain.crt.pem"
     ```
 
@@ -208,6 +210,7 @@ Install [tinkey](https://github.com/google/tink/blob/master/docs/TINKEY.md) firs
     --tink-keyset-path="enc-keyset.cfg"\
     --parent-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<intermediate-key>/versions/1"\
     --gcp-ca-parent="projects/<project>/locations/<location>/caPools/<pool-name>"\
+    --org-name="example.com"
     --output="chain.crt.pem"
   ```
 
@@ -226,6 +229,7 @@ Install [tinkey](https://github.com/google/tink/blob/master/docs/TINKEY.md) firs
     --tink-keyset-path="enc-keyset.cfg"\
     --parent-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<parent-key>/versions/1"\
     --parent-validity=<DAYS>
+    --org-name="example.com"
     --output="chain.crt.pem"
   ```
 

--- a/cmd/fetch-tsa-certs/fetch_tsa_certs.go
+++ b/cmd/fetch-tsa-certs/fetch_tsa_certs.go
@@ -92,6 +92,8 @@ var (
 	tinkKeysetPath = flag.String("tink-keyset-path", "", "Path to Tink keyset")
 	tinkKmsKey     = flag.String("tink-kms-resource", "", "Resource path to symmetric encryption KMS key to decrypt Tink keyset, starting with gcp-kms:// or aws-kms://")
 
+	orgName = flag.String("org-name", "", "Issuer organization name to use in created certificates")
+
 	outputPath = flag.String("output", "", "Path to write the certificate chain to")
 )
 
@@ -140,7 +142,7 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 			SerialNumber: parentSn,
 			Subject: pkix.Name{
 				CommonName:   "sigstore-tsa-selfsigned",
-				Organization: []string{"sigstore.dev"},
+				Organization: []string{*orgName},
 			},
 			SubjectKeyId:          parentSkid,
 			NotBefore:             now,
@@ -194,7 +196,7 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 						SubjectConfig: &privatecapb.CertificateConfig_SubjectConfig{
 							Subject: &privatecapb.Subject{
 								CommonName:   "sigstore-tsa-intermediate",
-								Organization: "sigstore.dev",
+								Organization: *orgName,
 							},
 						},
 					},
@@ -274,7 +276,7 @@ func fetchCertificateChain(ctx context.Context, root, parentKMSKey, leafKMSKey, 
 		SerialNumber: sn,
 		Subject: pkix.Name{
 			CommonName:   "sigstore-tsa",
-			Organization: []string{"sigstore.dev"},
+			Organization: []string{*orgName},
 		},
 		SubjectKeyId: skid,
 		NotBefore:    parent.NotBefore,


### PR DESCRIPTION
This new option allows setting the issuer organization name that the created certificates will use.

The current default of "sigstore.dev" is removed so possible other users don't use that by default: current default is "".

-- 

@haydentherapper I'm making this PR based on discussion in https://github.com/sigstore/root-signing-staging/pull/244.


Manually tested, "--org-name sigstage.dev" leads to `Issuer: O=sigstage.dev, CN=sigstore-tsa-selfsigned`