### PR TITLE
Fix: Disallow timestamp requests where digest length is inconsistent with hash algorithm

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	failedToGenerateTimestampResponse = "Error generating timestamp response"
-	WeakHashAlgorithmTimestampRequest = "Weak hash algorithm in timestamp request"
+	failedToGenerateTimestampResponse        = "Error generating timestamp response"
+	WeakHashAlgorithmTimestampRequest        = "Weak hash algorithm in timestamp request"
+	InconsistentDigestLengthTimestampRequest = "Message digest has incorrect length for specified algorithm"
 )
 
 func errorMsg(message string, code int) *models.Error {

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -99,23 +99,7 @@ func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 		TSAPolicyOID:  oidInts,
 	}
 
-	if err := verification.VerifyRequest(&tsReq); err != nil {
-		// verify that the request's hash algorithm is supported
-		if errors.Is(err, verification.ErrWeakHashAlg) {
-			return nil, WeakHashAlgorithmTimestampRequest, err
-		}
-		// verify that the request's hash algorithm is available
-		if errors.Is(err, verification.ErrUnavailableHashAlg) {
-			return nil, failedToGenerateTimestampResponse, err
-		}
-		// verify that the request's digest length is consistent with the request's hash algorithm
-		if errors.Is(err, verification.ErrInconsistentDigestLength) {
-			return nil, InconsistentDigestLengthTimestampRequest, err
-		}
-		return nil, failedToGenerateTimestampResponse, err
-	}
-
-	return &tsReq, "", nil
+	return VerifyTimestampRequest(&tsReq)
 }
 
 func parseDERRequest(reqBytes []byte) (*timestamp.Request, string, error) {
@@ -124,23 +108,7 @@ func parseDERRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 		return nil, failedToGenerateTimestampResponse, err
 	}
 
-	if err := verification.VerifyRequest(parsed); err != nil {
-		// verify that the request's hash algorithm is supported
-		if errors.Is(err, verification.ErrWeakHashAlg) {
-			return nil, WeakHashAlgorithmTimestampRequest, err
-		}
-		// verify that the request's hash algorithm is available
-		if errors.Is(err, verification.ErrUnavailableHashAlg) {
-			return nil, failedToGenerateTimestampResponse, err
-		}
-		// verify that the request's digest length is consistent with the request's hash algorithm
-		if errors.Is(err, verification.ErrInconsistentDigestLength) {
-			return nil, InconsistentDigestLengthTimestampRequest, err
-		}
-		return nil, failedToGenerateTimestampResponse, err
-	}
-
-	return parsed, "", nil
+	return VerifyTimestampRequest(parsed)
 }
 
 func getContentType(r *http.Request) (string, error) {
@@ -214,4 +182,24 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 
 func GetTimestampCertChainHandler(_ ts.GetTimestampCertChainParams) middleware.Responder {
 	return ts.NewGetTimestampCertChainOK().WithPayload(api.certChainPem)
+}
+
+func VerifyTimestampRequest(tsReq *timestamp.Request) (*timestamp.Request, string, error) {
+	if err := verification.VerifyRequest(tsReq); err != nil {
+		// verify that the request's hash algorithm is supported
+		if errors.Is(err, verification.ErrWeakHashAlg) {
+			return nil, WeakHashAlgorithmTimestampRequest, err
+		}
+		// verify that the request's hash algorithm is supported
+		if errors.Is(err, verification.ErrUnsupportedHashAlg) {
+			return nil, failedToGenerateTimestampResponse, err
+		}
+		// verify that the request's digest length is consistent with the request's hash algorithm
+		if errors.Is(err, verification.ErrInconsistentDigestLength) {
+			return nil, InconsistentDigestLengthTimestampRequest, err
+		}
+		return nil, failedToGenerateTimestampResponse, err
+	}
+
+	return tsReq, "", nil
 }

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -99,7 +99,7 @@ func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 		TSAPolicyOID:  oidInts,
 	}
 
-	return VerifyTimestampRequest(&tsReq)
+	return verifyTimestampRequest(&tsReq)
 }
 
 func parseDERRequest(reqBytes []byte) (*timestamp.Request, string, error) {
@@ -108,7 +108,7 @@ func parseDERRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 		return nil, failedToGenerateTimestampResponse, err
 	}
 
-	return VerifyTimestampRequest(parsed)
+	return verifyTimestampRequest(parsed)
 }
 
 func getContentType(r *http.Request) (string, error) {
@@ -184,7 +184,7 @@ func GetTimestampCertChainHandler(_ ts.GetTimestampCertChainParams) middleware.R
 	return ts.NewGetTimestampCertChainOK().WithPayload(api.certChainPem)
 }
 
-func VerifyTimestampRequest(tsReq *timestamp.Request) (*timestamp.Request, string, error) {
+func verifyTimestampRequest(tsReq *timestamp.Request) (*timestamp.Request, string, error) {
 	if err := verification.VerifyRequest(tsReq); err != nil {
 		// verify that the request's hash algorithm is not weak
 		if errors.Is(err, verification.ErrWeakHashAlg) {

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -99,6 +99,22 @@ func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 		TSAPolicyOID:  oidInts,
 	}
 
+	if err := verification.VerifyRequest(&tsReq); err != nil {
+		// verify that the request's hash algorithm is supported
+		if errors.Is(err, verification.ErrWeakHashAlg) {
+			return nil, WeakHashAlgorithmTimestampRequest, err
+		}
+		// verify that the request's hash algorithm is available
+		if errors.Is(err, verification.ErrUnavailableHashAlg) {
+			return nil, failedToGenerateTimestampResponse, err
+		}
+		// verify that the request's digest length is consistent with the request's hash algorithm
+		if errors.Is(err, verification.ErrInconsistentDigestLength) {
+			return nil, InconsistentDigestLengthTimestampRequest, err
+		}
+		return nil, failedToGenerateTimestampResponse, err
+	}
+
 	return &tsReq, "", nil
 }
 

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -186,7 +186,7 @@ func GetTimestampCertChainHandler(_ ts.GetTimestampCertChainParams) middleware.R
 
 func VerifyTimestampRequest(tsReq *timestamp.Request) (*timestamp.Request, string, error) {
 	if err := verification.VerifyRequest(tsReq); err != nil {
-		// verify that the request's hash algorithm is supported
+		// verify that the request's hash algorithm is not weak
 		if errors.Is(err, verification.ErrWeakHashAlg) {
 			return nil, WeakHashAlgorithmTimestampRequest, err
 		}

--- a/pkg/verification/verify_request.go
+++ b/pkg/verification/verify_request.go
@@ -23,17 +23,17 @@ import (
 )
 
 var ErrWeakHashAlg = errors.New("weak hash algorithm: must be SHA-256, SHA-384, or SHA-512")
-var ErrUnavailableHashAlg = errors.New("unavailable hash algorithm")
+var ErrUnsupportedHashAlg = errors.New("unsupported hash algorithm")
 var ErrInconsistentDigestLength = errors.New("digest length inconsistent with specified hash algorithm")
 
 func VerifyRequest(ts *timestamp.Request) error {
 	// only SHA-1, SHA-256, SHA-384, and SHA-512 are supported by the underlying library
-	if ts.HashAlgorithm == crypto.SHA1 {
+	switch ts.HashAlgorithm {
+	case crypto.SHA1:
 		return ErrWeakHashAlg
-	}
-
-	if !ts.HashAlgorithm.Available() {
-		return ErrUnavailableHashAlg
+	case crypto.SHA256, crypto.SHA384, crypto.SHA512:
+	default:
+		return ErrUnsupportedHashAlg
 	}
 
 	expectedDigestLength := ts.HashAlgorithm.Size()

--- a/pkg/verification/verify_request_test.go
+++ b/pkg/verification/verify_request_test.go
@@ -49,10 +49,9 @@ func TestVerifyRequest(t *testing.T) {
 			expectedError: ErrWeakHashAlg,
 		},
 		{
-			name: "Unavailable Hash Algorithm",
-			// crypto.Hash(0) is an "unknown hash function," so Available() returns false.
-			tsReq:         &timestamp.Request{HashAlgorithm: crypto.Hash(0), HashedMessage: make([]byte, 32)},
-			expectedError: ErrUnavailableHashAlg,
+			name:          "Unsupported Hash Algorithm",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA224, HashedMessage: make([]byte, crypto.SHA224.Size())},
+			expectedError: ErrUnsupportedHashAlg,
 		},
 		{
 			name:          "Inconsistent Digest Length",

--- a/pkg/verification/verify_request_test.go
+++ b/pkg/verification/verify_request_test.go
@@ -16,23 +16,64 @@ package verification
 
 import (
 	"crypto"
+	"errors"
 	"testing"
 
 	"github.com/digitorus/timestamp"
 )
 
 func TestVerifyRequest(t *testing.T) {
-	tsReq := &timestamp.Request{}
-
-	for _, alg := range []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512} {
-		tsReq.HashAlgorithm = alg
-		if err := VerifyRequest(tsReq); err != nil {
-			t.Fatalf("unexpected error verifying request, got %v", err)
-		}
+	tests := []struct {
+		name          string
+		tsReq         *timestamp.Request
+		expectedError error
+	}{
+		{
+			name:          "Valid SHA256",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA256, HashedMessage: make([]byte, crypto.SHA256.Size())},
+			expectedError: nil,
+		},
+		{
+			name:          "Valid SHA384",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA384, HashedMessage: make([]byte, crypto.SHA384.Size())},
+			expectedError: nil,
+		},
+		{
+			name:          "Valid SHA512",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA512, HashedMessage: make([]byte, crypto.SHA512.Size())},
+			expectedError: nil,
+		},
+		{
+			name:          "Weak Hash SHA1",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA1, HashedMessage: make([]byte, crypto.SHA1.Size())},
+			expectedError: ErrWeakHashAlg,
+		},
+		{
+			name: "Unavailable Hash Algorithm",
+			// crypto.Hash(0) is an "unknown hash function," so Available() returns false.
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.Hash(0), HashedMessage: make([]byte, 32)},
+			expectedError: ErrUnavailableHashAlg,
+		},
+		{
+			name:          "Inconsistent Digest Length",
+			tsReq:         &timestamp.Request{HashAlgorithm: crypto.SHA256, HashedMessage: make([]byte, 31)}, // SHA256 size is 32
+			expectedError: ErrInconsistentDigestLength,
+		},
 	}
 
-	tsReq.HashAlgorithm = crypto.SHA1
-	if err := VerifyRequest(tsReq); err != ErrWeakHashAlg {
-		t.Fatalf("expected error with weak hash algorithm, got %v", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := VerifyRequest(tc.tsReq)
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil", tc.expectedError)
+				}
+				if !errors.Is(err, tc.expectedError) {
+					t.Fatalf("expected error to be or wrap %v, but got %v (error message: %q)", tc.expectedError, err, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, but got %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes: #1064 
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
The timestamp authority accepts timestamp requests whose `hashMessage` has a digest length inconsistent with that required by RFC 3161 for its `hashAlgorithm`. This change adds validation to `VerifyRequest` to ensure that, for a timestamp request, the digest of the `hashMessage` matches the length of the digest resulting from the `hashAlgorithm`.
