### PR TITLE
Relax EKU chaining rules verification for intermediate certs

### DIFF
--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -450,7 +450,7 @@ func TestVerifyESSCertID(t *testing.T) {
 	}
 }
 
-func TestVerifyExtendedKeyUsage(t *testing.T) {
+func TestVerifyLeafExtendedKeyUsage(t *testing.T) {
 	type test struct {
 		eku                 []x509.ExtKeyUsage
 		expectVerifySuccess bool
@@ -476,9 +476,53 @@ func TestVerifyExtendedKeyUsage(t *testing.T) {
 			ExtKeyUsage: tc.eku,
 		}
 
-		err := verifyExtendedKeyUsage(&cert)
+		err := verifyLeafExtendedKeyUsage(&cert)
 		if err != nil && tc.expectVerifySuccess {
-			t.Errorf("expected verifyExtendedKeyUsage to return nil error")
+			t.Errorf("expected verifyLeafExtendedKeyUsage to return nil error")
+		}
+		if err == nil && !tc.expectVerifySuccess {
+			t.Errorf("expected verification to fail")
+		}
+	}
+}
+
+func TestVerifyIntermediateExtendedKeyUsage(t *testing.T) {
+	type test struct {
+		eku                 []x509.ExtKeyUsage
+		expectVerifySuccess bool
+	}
+
+	tests := []test{
+		{
+			eku:                 []x509.ExtKeyUsage{},
+			expectVerifySuccess: true,
+		},
+		{
+			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+			expectVerifySuccess: true,
+		},
+		{
+			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping, x509.ExtKeyUsageIPSECTunnel},
+			expectVerifySuccess: true,
+		},
+		{
+			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageAny, x509.ExtKeyUsageIPSECTunnel},
+			expectVerifySuccess: true,
+		},
+		{
+			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageIPSECTunnel},
+			expectVerifySuccess: false,
+		},
+	}
+
+	for _, tc := range tests {
+		cert := x509.Certificate{
+			ExtKeyUsage: tc.eku,
+		}
+
+		err := verifyIntermediateExtendedKeyUsage(&cert)
+		if err != nil && tc.expectVerifySuccess {
+			t.Errorf("expected verifyIntermediateExtendedKeyUsage to return nil error")
 		}
 		if err == nil && !tc.expectVerifySuccess {
 			t.Errorf("expected verification to fail")


### PR DESCRIPTION
#### Summary
Fixes issue discussed in [#3632](https://github.com/sigstore/cosign/issues/3632)

This PR relaxes EKU chaining rules for TSA intermediate certs. Intermediates can have no EKU (means unrestricted usage) or multiple EKUs, which include either `Timestamping` or `UsageAny`. 

This would allow using cosign with more self-signed, private and publicly available timestamp authorities 

#### Release Note
* TSA certchain verification no longer requires strict single Timestamping EKU for intermediate certs

#### Testing done
Verified using unit tests

