### PR TITLE
Allow full issuing chain in response

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -61,6 +61,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&httpPingOnly, "http-ping-only", false, "serve only /ping in the http server")
 	rootCmd.PersistentFlags().String("timestamp-signer", "memory", "Timestamping authority signer. Valid options include: [kms, tink, memory, file]. Memory and file-based signers should only be used for testing")
 	rootCmd.PersistentFlags().String("timestamp-signer-hash", "sha256", "Hash algorithm used by the signer. Must match the hash algorithm specified for a KMS or Tink key. Valid options include: [sha256, sha384, sha512]. Ignored for Memory signer.")
+	rootCmd.PersistentFlags().Bool("include-chain-in-response", false, "Whether to include the issuing chain in the timestamp response when certReq is set in the timestamp request. When false, only the leaf certificate is included in the response.")
 	// KMS flags
 	rootCmd.PersistentFlags().String("kms-key-resource", "", "KMS key for signing timestamp responses. Valid options include: [gcpkms://resource, azurekms://resource, hashivault://resource, awskms://resource]")
 	// Tink flags

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -38,6 +38,7 @@ type API struct {
 	tsaSignerHash crypto.Hash         // hash algorithm used to hash pre-signed timestamps
 	certChain     []*x509.Certificate // timestamping cert chain
 	certChainPem  string              // PEM encoded timestamping cert chain
+	includeChain  bool                // Whether to include the full issuing chain or just the leaf certificate
 }
 
 func NewAPI() (*API, error) {
@@ -91,6 +92,7 @@ func NewAPI() (*API, error) {
 		tsaSignerHash: tsaSignerHash,
 		certChain:     certChain,
 		certChainPem:  string(certChainPEM),
+		includeChain:  viper.GetBool("include-chain-in-response"),
 	}, nil
 }
 

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -171,6 +171,9 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 		AddTSACertificate: req.Certificates,
 		ExtraExtensions:   req.Extensions,
 	}
+	if api.includeChain {
+		tsStruct.Certificates = api.certChain[1:] // Issuing CA certificate down to root
+	}
 
 	resp, err := tsStruct.CreateResponseWithOpts(api.certChain[0], api.tsaSigner, api.tsaSignerHash)
 	if err != nil {

--- a/pkg/tests/api_test.go
+++ b/pkg/tests/api_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sigstore/timestamp-authority/pkg/client"
 	"github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
 	"github.com/sigstore/timestamp-authority/pkg/x509"
+	"github.com/spf13/viper"
 
 	"github.com/go-openapi/runtime"
 	"go.uber.org/goleak"
@@ -88,6 +89,7 @@ type timestampTestCase struct {
 	includeCerts bool
 	policyOID    asn1.ObjectIdentifier
 	hash         crypto.Hash
+	issuingChain bool
 }
 
 func TestGetTimestampResponse(t *testing.T) {
@@ -113,6 +115,15 @@ func TestGetTimestampResponse(t *testing.T) {
 			hash:         hashFunc,
 		},
 		{
+			name:         "Request with Full Issuing Chain",
+			reqMediaType: client.TimestampQueryMediaType,
+			reqBytes:     buildTimestampQueryReq(t, []byte(testArtifact), opts),
+			nonce:        testNonce,
+			includeCerts: includeCerts,
+			hash:         hashFunc,
+			issuingChain: true,
+		},
+		{
 			name:         "JSON Request",
 			reqMediaType: client.JSONMediaType,
 			reqBytes:     buildJSONReq(t, []byte(testArtifact), hashFunc, hashName, includeCerts, testNonce, ""),
@@ -123,7 +134,12 @@ func TestGetTimestampResponse(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		url := createServer(t)
+		var url string
+		if !tc.issuingChain {
+			url = createServer(t, func() { viper.Set("include-chain-in-response", false) })
+		} else {
+			url = createServer(t, func() { viper.Set("include-chain-in-response", true) })
+		}
 
 		c, err := client.GetTimestampClient(url, client.WithContentType(tc.reqMediaType))
 		if err != nil {
@@ -149,11 +165,29 @@ func TestGetTimestampResponse(t *testing.T) {
 		}
 
 		// check certificate fields
-		if len(tsr.Certificates) != 1 {
-			t.Fatalf("test '%s': expected 1 certificate, got %d", tc.name, len(tsr.Certificates))
-		}
 		if !tsr.AddTSACertificate {
 			t.Fatalf("test '%s': expected TSA certificate", tc.name)
+		}
+		if !tc.issuingChain {
+			if len(tsr.Certificates) != 1 {
+				t.Fatalf("test '%s': expected 1 certificate, got %d", tc.name, len(tsr.Certificates))
+			}
+			if tsr.Certificates[0].Subject.CommonName != "Test TSA Timestamping" {
+				t.Fatalf("test '%s': expected subject to be 'Test TSA Timestamping', got %s", tc.name, tsr.Certificates[0].Subject.CommonName)
+			}
+		} else {
+			if len(tsr.Certificates) != 3 {
+				t.Fatalf("test '%s': expected 3 certificates, got %d", tc.name, len(tsr.Certificates))
+			}
+			if tsr.Certificates[0].Subject.CommonName != "Test TSA Timestamping" {
+				t.Fatalf("test '%s': expected subject to be 'Test TSA Timestamping', got %s", tc.name, tsr.Certificates[0].Subject.CommonName)
+			}
+			if tsr.Certificates[1].Subject.CommonName != "Test TSA Intermediate" {
+				t.Fatalf("test '%s': expected subject to be 'Test TSA Intermediate', got %s", tc.name, tsr.Certificates[1].Subject.CommonName)
+			}
+			if tsr.Certificates[2].Subject.CommonName != "Test TSA Root" {
+				t.Fatalf("test '%s': expected subject to be 'Test TSA Root', got %s", tc.name, tsr.Certificates[2].Subject.CommonName)
+			}
 		}
 		// check nonce
 		if tsr.Nonce.Cmp(tc.nonce) != 0 {

--- a/pkg/tests/server.go
+++ b/pkg/tests/server.go
@@ -26,9 +26,12 @@ import (
 	"github.com/sigstore/timestamp-authority/pkg/server"
 )
 
-func createServer(t *testing.T) string {
+func createServer(t *testing.T, flagsToSet ...func()) string {
 	viper.Set("timestamp-signer", "memory")
 	viper.Set("timestamp-signer-hash", "sha256")
+	for _, flag := range flagsToSet {
+		flag()
+	}
 	// unused port
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, false, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())


### PR DESCRIPTION
Fixes #1079

Per RFC3161, when the certReq field is set to true, the TSA's certificate will be present in the timestamp response, and optionally other certificates may be present. Other public TSAs provide the full issuing chain in the response.

This PR adds a server configuration flag to include the full chain in the response if the certReq bit is true.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
