### PR TITLE
fix panic in cosign verify-attestation

### DIFF
--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -285,7 +285,16 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) error {
 	if len(opts.Roots) == 0 {
 		return fmt.Errorf("no root certificates provided for verifying the certificate chain")
 	}
-
+	rootFound := false
+	for _, cert := range opts.Roots {
+		if cert != nil {
+			rootFound = true
+			break
+		}
+	}
+	if !rootFound {
+		return fmt.Errorf("no valid root certificates provided for verifying the certificate chain - nil opts.Roots")
+	}
 	rootCertPool := x509.NewCertPool()
 	for _, cert := range opts.Roots {
 		rootCertPool.AddCert(cert)

--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -285,24 +285,18 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) error {
 	if len(opts.Roots) == 0 {
 		return fmt.Errorf("no root certificates provided for verifying the certificate chain")
 	}
-	rootFound := false
-	for _, cert := range opts.Roots {
-		if cert != nil {
-			rootFound = true
-			break
-		}
-	}
-	if !rootFound {
-		return fmt.Errorf("no valid root certificates provided for verifying the certificate chain - nil opts.Roots")
-	}
 	rootCertPool := x509.NewCertPool()
 	for _, cert := range opts.Roots {
-		rootCertPool.AddCert(cert)
+		if cert != nil {
+			rootCertPool.AddCert(cert)
+		}
 	}
 
 	intermediateCertPool := x509.NewCertPool()
 	for _, cert := range opts.Intermediates {
-		intermediateCertPool.AddCert(cert)
+		if cert != nil {
+			intermediateCertPool.AddCert(cert)
+		}
 	}
 
 	x509Opts := x509.VerifyOptions{

--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -291,7 +291,9 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) error {
 			rootCertPool.AddCert(cert)
 		}
 	}
-
+	if rootCertPool.Equal(x509.NewCertPool()) {
+		return fmt.Errorf("no valid root certificates provided for verifying the certificate chain")
+	}
 	intermediateCertPool := x509.NewCertPool()
 	for _, cert := range opts.Intermediates {
 		if cert != nil {

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -629,6 +629,15 @@ func TestVerifyTSRWithChain(t *testing.T) {
 			expectVerifySuccess: true,
 		},
 		{
+			name: "Verification fails due to invalid nil root certificate",
+			ts:   tsWithCerts,
+			opts: VerifyOpts{
+				Roots:         []*x509.Certificate{nil},
+				Intermediates: []*x509.Certificate{intermediate},
+			},
+			expectVerifySuccess: false,
+		},
+		{
 			name: "Verification fails due to invalid intermediate certificate",
 			ts:   tsWithCerts,
 			opts: VerifyOpts{

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -690,11 +690,13 @@ func TestVerifyTSRWithChain(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		err = verifyTSRWithChain(tc.ts, tc.opts)
-		if tc.expectVerifySuccess && err != nil {
-			t.Errorf("test '%s' unexpectedly failed \nExpected verifyTSRWithChain to successfully verify certificate chain, err: %v", tc.name, err)
-		} else if !tc.expectVerifySuccess && err == nil {
-			t.Errorf("testg '%s' unexpectedly passed \nExpected verifyTSRWithChain to fail verification", tc.name)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			err = verifyTSRWithChain(tc.ts, tc.opts)
+			if tc.expectVerifySuccess && err != nil {
+				t.Errorf("unexpectedly failed \nExpected verifyTSRWithChain to successfully verify certificate chain, err: %v", err)
+			} else if !tc.expectVerifySuccess && err == nil {
+				t.Errorf("unexpectedly passed \nExpected verifyTSRWithChain to fail verification")
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### Summary
Fix panic in `cosign verify-attestation --trusted-root trustedroot.json` due to adding a nil root certificate to the CertPool. See sigstore/cosign issue
[sigstore/cosign#4261](https://github.com/sigstore/cosign/issues/4261).

For even more robust fix, I will also do a PR in sigstore-go to avoid calling `verifyTSRWithChain` with bad / invalid `VerifyOpts`.

#### Verification
* When running the new unit test against the trunk version, getting "red" - the expected failure [gist](https://gist.github.com/dmitris/889fca18dba0a69aab9f6ca761b61e65).

* confirmed that when building `cosign` using the version of this PR (with `replace github.com/sigstore/timestamp-authority => ../timestamp-authority` in sigstore/cosign/go.mod), I no longer get a panic, the error is "regular":
```
Error: no matching attestations: failed to verify timestamps: threshold not met for verified signed timestamps: 0 < 1; error: unable to verify signed timestamps: error while verifying with chain: pkcs7: failed to verify certificate chain: x509: certificate signed by unknown authority
no valid root certificates provided for verifying the certificate chain - nil opts.Roots
error during command execution: no matching attestations: failed to verify timestamps: threshold not met for verified signed timestamps: 0 < 1; error: unable to verify signed timestamps: error while verifying with chain: pkcs7: failed to verify certificate chain: x509: certificate signed by unknown authority
no valid root certificates provided for verifying the certificate chain - nil opts.Roots
```

#### Release Note
* Bug fixes and fixes of previous known issues
Fix panic in `cosign verify-attestation` when using a trustedroot file.

#### Documentation
N/A
