### PR TITLE
add feature to disable intermediate cert EKU enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ To deploy to production, the timestamp authority currently supports signing with
 a certificate chain (leaf, any intermediates, and root), where the certificate chain's purpose (extended key usage) is
 for timestamping. We do not recommend the file signer for production since the signing key will only be password protected.
 
+#### Intermediate Certificates
+
+Note that the default is for `timestamp-server` to enforce that both the leaf certificate *and* any intermediate certificates have extended key usage of timestamping and set as critical. If you wish to disable this enforcement for intermediates, set `--enforce-intermediate-eku=false`.
+
 ### Certificate Maker
 
 Certificate Maker is a tool for creating RFC 3161 compliant certificate chains for Timestamp Authority. It supports:

--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	cfgFile      string
-	logType      string
-	enablePprof  bool
-	httpPingOnly bool
+	cfgFile                string
+	logType                string
+	enablePprof            bool
+	httpPingOnly           bool
+	enforceIntermediateEku bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,6 +60,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logType, "log-type", "dev", "logger type to use (dev/prod)")
 	rootCmd.PersistentFlags().BoolVar(&enablePprof, "enable-pprof", false, "enable pprof for profiling on port 6060")
 	rootCmd.PersistentFlags().BoolVar(&httpPingOnly, "http-ping-only", false, "serve only /ping in the http server")
+	rootCmd.PersistentFlags().BoolVar(&enforceIntermediateEku, "enforce-intermediate-eku", true, "enforce requirement for intermediate certificates to have timestamping EKU")
 	rootCmd.PersistentFlags().String("timestamp-signer", "memory", "Timestamping authority signer. Valid options include: [kms, tink, memory, file]. Memory and file-based signers should only be used for testing")
 	rootCmd.PersistentFlags().String("timestamp-signer-hash", "sha256", "Hash algorithm used by the signer. Must match the hash algorithm specified for a KMS or Tink key. Valid options include: [sha256, sha384, sha512]. Ignored for Memory signer.")
 	rootCmd.PersistentFlags().Bool("include-chain-in-response", false, "Whether to include the issuing chain in the timestamp response when certReq is set in the timestamp request. When false, only the leaf certificate is included in the response.")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -71,7 +71,7 @@ func NewAPI() (*API, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := tsx509.VerifyCertChain(certChain, tsaSigner); err != nil {
+		if err := tsx509.VerifyCertChain(certChain, tsaSigner, viper.GetBool("enforce-intermediate-eku")); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
add server command-line parameter to disable enforcement of requirement that intermediate certificates have the critical timestamping EKU present

Resolves: #1141

#### Summary

`timestamp-server` currently enforces any intermediate certificates also having the critical timestamping EKU present; this isn't required by RFC3161, and it looks like many of the online free/commercial timestamping providers don't adhere to this usage (e.g., Apple, Globalsign, Digicert). This commit adds a command-line option to disable this behavior, so that a server can use intermediate certificates without the critical timestamping EKU.

#### Release Notes

* Adds `--enforce-intermediate-eku` boolean command-line option, with a default of true, so the present behavior continues unless a server is started with the option present and set to `false`.
