### PR TITLE
logging: Don't use Error when logging 4xx responses

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -50,7 +50,11 @@ func handleTimestampAPIError(params interface{}, code int, err error, message st
 	handler := re.FindStringSubmatch(typeStr)[1]
 
 	logMsg := func(r *http.Request) {
-		log.RequestIDLogger(r).Errorw("exiting with error", append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message, "error", err}, fields...)...)
+		if code < http.StatusInternalServerError {
+			log.RequestIDLogger(r).Warnw(message, append([]interface{}{"handler", handler, "statusCode", code, "error", err}, fields...)...)
+		} else {
+			log.RequestIDLogger(r).Errorw(message, append([]interface{}{"handler", handler, "statusCode", code, "error", err}, fields...)...)
+		}
 		paramsFields := map[string]interface{}{}
 		if err := mapstructure.Decode(params, &paramsFields); err == nil {
 			log.RequestIDLogger(r).Debug(paramsFields)

--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -197,7 +197,7 @@ func cacheForDay(handler http.Handler) http.Handler {
 }
 
 func logAndServeError(w http.ResponseWriter, r *http.Request, err error) {
-	if apiErr, ok := err.(errors.Error); ok && apiErr.Code() == http.StatusNotFound {
+	if apiErr, ok := err.(errors.Error); ok && apiErr.Code() < http.StatusInternalServerError {
 		log.RequestIDLogger(r).Warn(err)
 	} else {
 		log.RequestIDLogger(r).Error(err)


### PR DESCRIPTION
The main change is the log type change in handleTimestampAPIError() but there's other small tweaks:
* in the error.go case also avoid the misleading "exiting with error" message and use the original message instead.
* make sure the two handlers use the same logic to choose between error and warning

This came up in https://github.com/sigstore/rekor-tiles/issues/483