### PR TITLE
Minor improvements to documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <tac@sigstore.dev>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,8 +63,7 @@ See also: #456, #789
 Note the `Resolves #123` tag, this references the issue raised and allows us to
 ensure issues are associated and closed when a pull request is merged.
 
-Please refer to [the github help page on message types](https://help.github.com/articles/closing-issues-using-keywords/)
-for a complete list of issue references.
+Please refer to [the github help page on message types](https://help.github.com/articles/closing-issues-using-keywords/) for a complete list of issue references.
 
 ## Squash Commits
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -129,4 +129,4 @@ Origin](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signo
 ## Code of Conduct
 
 Sigstore Timestamp-Authority adheres to and enforces the [Contributor Covenant](http://contributor-covenant.org/version/1/4/) Code of Conduct.
-Please take a moment to read the [CODE_OF_CONDUCT.md](https://github.com/sigstore/timestamp-authority/blob/master/CODE_OF_CONDUCT.md) document.
+Please take a moment to read the [CODE_OF_CONDUCT.md](/CODE_OF_CONDUCT.md) document.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -122,7 +122,12 @@ git push origin your-branch --force
 
 Alternatively, a core member can squash your commits within Github.
 
+## DCO Signoff
+
+Make sure to sign the [Developer Certificate of
+Origin](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff).
+
 ## Code of Conduct
 
-{project-name} adheres to and enforces the [Contributor Covenant](http://contributor-covenant.org/version/1/4/) Code of Conduct.
-Please take a moment to read the [CODE_OF_CONDUCT.md](https://github.com/sigstore/timestamp-authority/blob/main/CODE_OF_CONDUCT.md) document.
+Sigstore Timestamp-Authority adheres to and enforces the [Contributor Covenant](http://contributor-covenant.org/version/1/4/) Code of Conduct.
+Please take a moment to read the [CODE_OF_CONDUCT.md](https://github.com/sigstore/timestamp-authority/blob/master/CODE_OF_CONDUCT.md) document.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,13 +12,13 @@ to make via an [issue](https://github.com/sigstore/timestamp-authority/issues).
 4. Update the README.md with details of changes to any interface, this includes new environment
    variables, exposed ports, useful file locations, CLI parameters and
    new or changed configuration values.
-5. Correctly format your commit message see [Commit Messages](#Commit-Message-Guidelines)
+5. Correctly format your commit message see [Commit Messages](#commit-message-guidelines)
    below.
 6. Ensure that CI passes, if it fails, fix the failures.
 7. Every pull request requires a review from the [core timestamp-authority team](https://github.com/orgs/github.com/sigstore/teams/tsa-codeowners)
    before merging.
 8. If your pull request consists of more than one commit, please squash your
-   commits as described in [Squash Commits](#Squash-Commits)
+   commits as described in [Squash Commits](#squash-commits)
 
 ## Commit Message Guidelines
 
@@ -30,7 +30,7 @@ are used to generate release notes.
 
 A good example of a commit message would be as follows:
 
-```
+```text
 Summarize changes in around 50 characters or less
 
 More detailed explanatory text, if necessary. Wrap it to about 72
@@ -74,39 +74,51 @@ once a reviewer has approved your pull request.
 
 A squash can be performed as follows. Let's say you have the following commits:
 
-    initial commit
-    second commit
-    final commit
+```text
+initial commit
+second commit
+final commit
+```
 
 Run the command below with the number set to the total commits you wish to
 squash (in our case 3 commits):
 
-    git rebase -i HEAD~3
+```shell
+git rebase -i HEAD~3
+```
 
-You default text editor will then open up and you will see the following::
+You default text editor will then open up and you will see the following:
 
-    pick eb36612 initial commit
-    pick 9ac8968 second commit
-    pick a760569 final commit
+```shell
+pick eb36612 initial commit
+pick 9ac8968 second commit
+pick a760569 final commit
 
-    # Rebase eb1429f..a760569 onto eb1429f (3 commands)
+# Rebase eb1429f..a760569 onto eb1429f (3 commands)
+```
 
 We want to rebase on top of our first commit, so we change the other two commits
 to `squash`:
 
-    pick eb36612 initial commit
-    squash 9ac8968 second commit
-    squash a760569 final commit
+```shell
+pick eb36612 initial commit
+squash 9ac8968 second commit
+squash a760569 final commit
+```
 
 After this, should you wish to update your commit message to better summarise
 all of your pull request, run:
 
-    git commit --amend
+```shell
+git commit --amend
+```
 
 You will then need to force push (assuming your initial commit(s) were posted
 to github):
 
-    git push origin your-branch --force
+```shell
+git push origin your-branch --force
+```
 
 Alternatively, a core member can squash your commits within Github.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The service expects the JSON body to be in the shape:
 }
 ```
 
-The artifact hash must be represented as a base64 encoded string.
+The artifact hash must be represented as a base64-encoded string.
 
 ## Production deployment
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The artifact hash must be represented as a base64 encoded string.
 ## Production deployment
 
 To deploy to production, the timestamp authority currently supports signing with Cloud KMS or
-[Tink](https://github.com/google/tink). You will need to provide
+[Tink](https://github.com/tink-crypto). You will need to provide
 a certificate chain (leaf, any intermediates, and root), where the certificate chain's purpose (extended key usage) is
 for timestamping. We do not recommend the file signer for production since the signing key will only be password protected.
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ As a artifact signer, you can:
 * Fetch a timestamp for that signature (more below in [What to sign](#what-to-sign))
 * Upload the signature, artifact hash, and certificate to Rekor (hashedrekord record type)
 * Upload the timestamp to Rekor (rfc3161 record type)
-   * This step is important because it makes the timestamps publicly auditable
+  * This step is important because it makes the timestamps publicly auditable
 
 As an artifact verifier:
 
 * Fetch the artifact entry from Rekor
 * If the artifact was signed with a certificate, verify its expiration
-   * If you trust Rekor's clock, verify the certificate with the timestamp in the Rekor response
-   * If you trust an external timestamp authority, fetch the timestamp from Rekor, verify the
+  * If you trust Rekor's clock, verify the certificate with the timestamp in the Rekor response
+  * If you trust an external timestamp authority, fetch the timestamp from Rekor, verify the
      signed timestamp, and verify the certificate using the signed timestamp
 
 ### What to sign
@@ -57,6 +57,7 @@ brew install openssl
 ```
 
 To launch the server, run either:
+
 * `docker-compose up`
 * `make timestamp-server && ./bin/timestamp-server serve --port 3000`
 
@@ -99,9 +100,9 @@ If you would like to make a request for a timestamp using a JSON based request, 
 
 The service expects the JSON body to be in the shape:
 
-```
+```json
 {
-  "artifactHash": "<base64 encoded artifact hash>",
+  "artifactHash": "<base64-encoded artifact hash>",
   "certificates": true,
   "hashAlgorithm": "sha256",
   "nonce": 1123343434,
@@ -137,7 +138,6 @@ For detailed usage instructions and examples, see the [Certificate Maker documen
 
 ### Cloud KMS
 
-
 Generate a certificate chain, which must include a leaf certificate whose public key pairs to the private key
 in cloud KMS, may include any number of intermediate certificates, and must include a root certificate.
 We recommend reviewing the [code](https://github.com/sigstore/timestamp-authority/blob/main/cmd/fetch-tsa-certs/fetch_tsa_certs.go)
@@ -150,6 +150,7 @@ used to generate the certificate chain if you do not want to use GCP.
 * Create an asymmetric certificate signing key on KMS that will be used as an intermediate CA to sign the TSA certificate.
 * Create an asymmetric timestamp signing key on KMS.
 * Run the following to create a certificate chain of root, intermediate and leaf certificates
+
     ```shell
     go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
       --leaf-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<timestamp-key>/versions/1" \
@@ -164,6 +165,7 @@ used to generate the certificate chain if you do not want to use GCP.
 * Create an asymmetric certificate signing key on KMS that will be used in the self-signed certificate to sign the TSA certificate.
 * Create an asymmetric timestamp signing key on KMS.
 * Run the following to create a chain of self-signed certificate and leaf signing certificate:
+
     ```shell
     go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
       --leaf-kms-resource="gcpkms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<timestamp-key>/versions/1" \
@@ -180,6 +182,7 @@ See [these instructions](docs/aws-kms.md) for the general process to use AWS KMS
 #### Other KMSs
 
 If you are not using GCP, there are many possible options but the steps for setting up the certificates could be similar to the following:
+
 * create a KMS private key (for example, in the AWS KMS)
 * use this private key to create a CSR
 * assuming you have an external (for example, corporate etc.) Certificate Authority entity
@@ -205,13 +208,16 @@ Install [tinkey](https://github.com/google/tink/blob/master/docs/TINKEY.md) firs
 
 * Create a symmetric key encryption key in GCP
 * Run the following to create the local encrypted signing key, changing key URI and the key template if desired:
+
     ```shell
     tinkey create-keyset --key-template ECDSA_P384 --out enc-keyset.cfg --master-key-uri gcp-kms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key-encryption-key>
     ```
+
 * Create a root CA with [GCP CA Service](https://cloud.google.com/certificate-authority-service). Configure lifetime, and other defaults
   can remain. You will need to first create a CA pool, and then create one CA in that pool.
 * Create an asymmetric signing key on KMS that will be used as an intermediate CA to sign the TSA certificate.
 * Run the following:
+
   ```shell
   go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
     --tink-kms-resource="gcp-kms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key-encryption-key>"\
@@ -226,11 +232,14 @@ Install [tinkey](https://github.com/google/tink/blob/master/docs/TINKEY.md) firs
 
 * Create a symmetric key encryption key in GCP
 * Run the following to create the local encrypted signing key, changing key URI and the key template if desired:
+
     ```shell
     tinkey create-keyset --key-template ECDSA_P384 --out enc-keyset.cfg --master-key-uri gcp-kms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key-encryption-key>
     ```
+
 * Create an asymmetric signing key on KMS that will be used in the self-signed certificate to sign the TSA certificate.
 * Run the following:
+
   ```shell
   go run cmd/fetch-tsa-certs/fetch_tsa_certs.go \
     --tink-kms-resource="gcp-kms://projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key-encryption-key>"\

--- a/docs/aws-kms.md
+++ b/docs/aws-kms.md
@@ -12,7 +12,7 @@ Once you've created the keys, you'll want to note the ARNs for each; you'll need
 
 Next, you will need to clone the [`fulcio`](https://github.com/sigstore/fulcio/) repository, which contains the Certificate Maker utility, and build the utility itself:
 
-```
+```shell
 git clone https://github.com/sigstore/fulcio/
 cd fulcio
 make cert-maker
@@ -26,36 +26,37 @@ Create a work directory somewhere, and create templates for your certificates (e
 
 Set your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables with values corresponding to the AWS identity which has permission to use your newly-created KMS keys, and then run `certificate-maker` to create your new certificates, replacing the `{YOUR-VALUE}` values:
 
-### Root and leaf certificates:
+### Root and leaf certificates
 
-```
+```shell
 /path/to/certificate-maker create \
-	--kms-type=awskms \
-	--aws-region={YOUR-REGION} \
-	--root-key-id={YOUR-ROOT-KEY-ARN} \
-	--leaf-key-id={YOUR-LEAF-KEY-ARN} \
-	--root-template=./root-template.json \
-	--leaf-template=./leaf-template.json
+    --kms-type=awskms \
+    --aws-region={YOUR-REGION} \
+    --root-key-id={YOUR-ROOT-KEY-ARN} \
+    --leaf-key-id={YOUR-LEAF-KEY-ARN} \
+    --root-template=./root-template.json \
+    --leaf-template=./leaf-template.json
 ```
 
-### Root, intermediate, and leaf certificates:
+### Root, intermediate, and leaf certificates
 
-```
+```shell
 /path/to/certificate-maker create \
-	--kms-type=awskms \
-	--aws-region={YOUR-REGION} \
-	--root-key-id={YOUR-ROOT-KEY-ARN} \
-	--intermediate-key-id={YOUR-INTERMEDIATE-KEY-ARN} \
-	--leaf-key-id={YOUR-LEAF-KEY-ARN} \
-	--root-template=./root-template.json \
-	--intermediate-template=./intermediate-template.json \
-	--leaf-template=./leaf-template.json
+    --kms-type=awskms \
+    --aws-region={YOUR-REGION} \
+    --root-key-id={YOUR-ROOT-KEY-ARN} \
+    --intermediate-key-id={YOUR-INTERMEDIATE-KEY-ARN} \
+    --leaf-key-id={YOUR-LEAF-KEY-ARN} \
+    --root-template=./root-template.json \
+    --intermediate-template=./intermediate-template.json \
+    --leaf-template=./leaf-template.json
 ```
+
 This should result in files for each of your new certificates (e.g., `root.pem`, `leaf.pem`, and then `intermediate.pem` if you generated an intermediate certificate).
 
 Concatenate all your certificates into a single file, with the leaf certificate first, the intermediate cert next (if you generated one), and then the root certificate:
 
-```
+```shell
 cat leaf.pem intermediate.pem root.pem > certchain.pem
 ```
 
@@ -63,14 +64,14 @@ cat leaf.pem intermediate.pem root.pem > certchain.pem
 
 Finally, run `timestamp-server`, specifying that your timestamp authority signer is a KMS, pointing it to your full certificate chain, and providing the ARN for the AWS KMS key you created for your leaf certificate (noting that AWS KMS keys are specified with the prefix `awskms:///`, with **three** slashes before the ARN):
 
-```
+```shell
 timestamp-server serve \
-	--host=0.0.0.0 \
-	--port=3004 \
-	--timestamp-signer=kms \
-	--certificate-chain-path=/path/to/certchain.pem \
-	--kms-key-resource=awskms:///{YOUR-LEAF-KEY-ARN} \
-	--log-type=prod
+    --host=0.0.0.0 \
+    --port=3004 \
+    --timestamp-signer=kms \
+    --certificate-chain-path=/path/to/certchain.pem \
+    --kms-key-resource=awskms:///{YOUR-LEAF-KEY-ARN} \
+    --log-type=prod
 ```
 
 (Note that the shell running `timestamp-server` needs to have access to the AWS access key and secret for the identity with permission to use the leaf key, so you'll need to either export environment variables for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or have Docker set the environemnt variables appropriately, or however else you're choosing to run the server.)

--- a/docs/certificate-maker.md
+++ b/docs/certificate-maker.md
@@ -2,11 +2,11 @@
 
 _Note: Certificate Maker can be [found in the Fulcio repository](https://github.com/sigstore/fulcio/tree/main/cmd/certificate_maker). Please refer to its [respective documentation](https://github.com/sigstore/fulcio/blob/main/docs/certificate-maker.md) to learn more._
 
-The TSA-specific certificate templates located in the `pkg/certmaker/templates` can be used with Certificate Maker.
+The TSA-specific certificate templates located in the `/pkg/certmaker/templates` can be used with Certificate Maker.
 
 ## Templates
 
-These [TSA-specific certificate templates](pkg/certmaker/templates) are specifically configured for Timestamp Authority certificates with appropriate extensions and constraints:
+These [TSA-specific certificate templates](/pkg/certmaker/templates) are specifically configured for Timestamp Authority certificates with appropriate extensions and constraints:
 
 - `root-template.json`: Template for root CA certificates
 - `intermediate-template.json`: Template for intermediate CA certificates

--- a/release/README.md
+++ b/release/README.md
@@ -2,10 +2,11 @@
 
 This directory contain the files and scripts to run a timestamp release.
 
-# Cutting a timestamp Release
+## Cutting a timestamp Release
 
 1. Release notes: Create a PR to update and review release notes in [CHANGELOG.md](../CHANGELOG.md).
-  - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
+  
+- Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
 
 You can get a list of pull requests since the last release by substituting in the date of the last release and running:
 
@@ -19,7 +20,7 @@ and a list of authors by running:
 git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
 ```
 
-1. Merge the CHANGELOG.md pull request 
+1. Merge the CHANGELOG.md pull request
 
 1. Sync your repository's main branch and tag the repository
 

--- a/release/README.md
+++ b/release/README.md
@@ -9,13 +9,13 @@ This directory contain the files and scripts to run a timestamp release.
 
 You can get a list of pull requests since the last release by substituting in the date of the last release and running:
 
-```
+```shell
 git log --pretty="* %s" --after="YYYY-MM-DD"
 ```
 
 and a list of authors by running:
 
-```
+```shell
 git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
 ```
 
@@ -24,16 +24,17 @@ git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
 1. Sync your repository's main branch and tag the repository
 
 ```shell
-$ export RELEASE_TAG=<release version, eg "v1.1.0">
-$ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
-$ git push upstream ${RELEASE_TAG}
+export RELEASE_TAG=<release version, eg "v1.1.0">
+git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
+git push upstream ${RELEASE_TAG}
 ```
 
 Note that `upstream` should be the upstream Sigstore repository. You may have to change this if you've configured remotes.
 
 Add the Sigstore repository as `upstream` with the following:
+
 ```shell
-$ git remote add upstream git@github.com:sigstore/timestamp-authority.git
+git remote add upstream git@github.com:sigstore/timestamp-authority.git
 ```
 
 1. This will trigger a GitHub Workflow that will build the binaries and the images.

--- a/release/README.md
+++ b/release/README.md
@@ -4,7 +4,7 @@ This directory contain the files and scripts to run a timestamp release.
 
 ## Cutting a timestamp Release
 
-1. Release notes: Create a PR to update and review release notes in [CHANGELOG.md](../CHANGELOG.md).
+1. Release notes: Create a PR to update and review release notes in [CHANGELOG.md](/CHANGELOG.md).
   
 - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Resolves #1168 

Initially, I just wanted to fix the broken link to [certificate-maker's templates](https://github.com/sigstore/timestamp-authority/tree/main/pkg/certmaker/templates) that I personally encountered when working with this project. In doing so, I did a tiny bit of linting in the hopes of finding other dead links (which [David Anson's markdown linter](https://github.com/DavidAnson/markdownlint) doesn't appear to do). I fixed some things I thought were worth fixing while I was here,

- updated the internal broken link of #1168
- updated other internal doc. links with the above root '/' ref.
- added language to code blocks
- added code of conduct (as present in other Sigstore repositories)
- updated external link to now-split Tink-org. repositories

#### Release 

NONE (exclusively documentation).
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
Sort of. No update to https://docs.sigstore.dev. Just to the documentation within this repository. 
