### PR TITLE
feat: add configurable max request body size for TSA server

### DIFF
--- a/cmd/timestamp-server/app/serve.go
+++ b/cmd/timestamp-server/app/serve.go
@@ -122,4 +122,9 @@ var serveCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(version.Version())
+
+	serveCmd.Flags().Int64("max-request-body-size", 1048576, "Maximum allowed size for request bodies in bytes (1MB by default)")
+	if err := viper.BindPFlags(serveCmd.Flags()); err != nil {
+		log.Logger.Fatal(err)
+	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

<!--What needs to be improved? What should be done? Has there been any related work
before? Any relevant links or material?
-->

Currently, the Timestamp Authority (TSA) server does not limit the size of incoming requests. While RFC 3161 requests are expected to be very small (typically a few hundred bytes), there is no protection against abnormally large or malicious requests that could lead to high memory usage or DoS attacks.

**Proposed change**
- Add a new CLI flag `--max-request-body-size` (default: 1 MB) to the timestamp-server command.
- Use this flag to limit the size of incoming HTTP request bodies via a middleware (`http.MaxBytesReader`).
- Ensure that requests exceeding the limit are rejected.

Issue: https://github.com/sigstore/timestamp-authority/issues/1175
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
