### PR TITLE
Bound path and HTTP method metric label cardinality to prevent OOM

### DIFF
--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -135,6 +135,7 @@ func limitRequestBody(next http.Handler) http.Handler {
 			if maxRequestBodySize > uint64(math.MaxInt64) {
 				log.Logger.Fatalf("max-request-body-size (%v) exceeds supported maximum (%v)", maxRequestBodySize, maxInt64Limit)
 			}
+			// #nosec G115
 			r.Body = http.MaxBytesReader(w, r.Body, int64(maxRequestBodySize))
 		} else {
 			log.Logger.Debug("max-request-body-size is set to 0; no limit will be enforced on request body sizes")
@@ -178,25 +179,41 @@ func wrapMetrics(handler http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		defer func() {
+			path := r.URL.Path
+			switch path {
+			case pingPath, "/api/v1/timestamp", "/api/v1/timestamp/certchain":
+				// Keep path as is
+			default:
+				path = "unrecognized"
+			}
+
+			method := r.Method
+			switch method {
+			case http.MethodGet, http.MethodPost, http.MethodHead, http.MethodOptions:
+				// Keep method as is
+			default:
+				method = "unrecognized"
+			}
+
 			// This logs latency broken down by URL path and response code
 			pkgapi.MetricLatency.With(map[string]string{
-				"path": r.URL.Path,
+				"path": path,
 				"code": strconv.Itoa(ww.Status()),
 			}).Observe(float64(time.Since(start)))
 
 			pkgapi.MetricLatencySummary.With(map[string]string{
-				"path": r.URL.Path,
+				"path": path,
 				"code": strconv.Itoa(ww.Status()),
 			}).Observe(float64(time.Since(start)))
 
 			pkgapi.MetricRequestLatency.With(map[string]string{
-				"path":   r.URL.Path,
-				"method": r.Method,
+				"path":   path,
+				"method": method,
 			}).Observe(float64(time.Since(start)))
 
 			pkgapi.MetricRequestCount.With(map[string]string{
-				"path":   r.URL.Path,
-				"method": r.Method,
+				"path":   path,
+				"method": method,
 				"code":   strconv.Itoa(ww.Status()),
 			}).Inc()
 		}()

--- a/pkg/generated/restapi/configure_timestamp_server_test.go
+++ b/pkg/generated/restapi/configure_timestamp_server_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	pkgapi "github.com/sigstore/timestamp-authority/v2/pkg/api"
+)
+
+func TestWrapMetrics(t *testing.T) {
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := wrapMetrics(dummyHandler)
+
+	tests := []struct {
+		name           string
+		path           string
+		method         string
+		expectedPath   string
+		expectedMethod string
+	}{
+		{
+			name:           "Valid ping route GET",
+			path:           "/ping",
+			method:         "GET",
+			expectedPath:   "/ping",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "Valid timestamp route POST",
+			path:           "/api/v1/timestamp",
+			method:         "POST",
+			expectedPath:   "/api/v1/timestamp",
+			expectedMethod: "POST",
+		},
+		{
+			name:           "Valid certchain route GET",
+			path:           "/api/v1/timestamp/certchain",
+			method:         "GET",
+			expectedPath:   "/api/v1/timestamp/certchain",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "Unrecognized route GET",
+			path:           "/invalid/route",
+			method:         "GET",
+			expectedPath:   "unrecognized",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "Unrecognized route with valid suffix",
+			path:           "/api/v1/timestamp/extra",
+			method:         "GET",
+			expectedPath:   "unrecognized",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "Unrecognized route with trailing slash",
+			path:           "/api/v1/timestamp/",
+			method:         "POST",
+			expectedPath:   "unrecognized",
+			expectedMethod: "POST",
+		},
+		{
+			name:           "Unrecognized HTTP Method",
+			path:           "/api/v1/timestamp",
+			method:         "CUSTOM_METHOD",
+			expectedPath:   "/api/v1/timestamp",
+			expectedMethod: "unrecognized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset metrics before each subtest to isolate counts
+			pkgapi.MetricRequestCount.Reset()
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rr := httptest.NewRecorder()
+
+			wrapped.ServeHTTP(rr, req)
+
+			count := testutil.ToFloat64(pkgapi.MetricRequestCount.With(map[string]string{
+				"path":   tt.expectedPath,
+				"method": tt.expectedMethod,
+				"code":   "200",
+			}))
+
+			if count != 1 {
+				t.Errorf("expected metric request count to be 1, got %f for labels path=%q, method=%q, code=200", count, tt.expectedPath, tt.expectedMethod)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Unauthenticated remote attackers can trigger unbounded Prometheus metric cardinality and cause server-side memory exhaustion (OOM) by sending requests with unique request paths or custom HTTP methods.

To mitigate this, this change normalizes the URL path and methods to an allowlist of valid routes and HTTP methods.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
