### PR TITLE
Fix spec violations in policy, EKU, and hash verification

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -86,6 +86,10 @@ func init() {
 	rootCmd.PersistentFlags().Uint64("max-request-body-size", 1048576, "Maximum allowed size for request bodies in bytes (1MB by default)")
 	rootCmd.PersistentFlags().Duration("cleanup-timeout", 620*time.Second, "grace period for which to wait before killing idle connections")
 
+	rootCmd.PersistentFlags().String("default-policy-oid", "1.3.6.1.4.1.57264.2", "Default policy OID to use if none is specified in the request")
+	rootCmd.PersistentFlags().StringSlice("accepted-policy-oids", []string{"1.3.6.1.4.1.57264.2"}, "List of policy OIDs accepted in timestamp requests")
+	rootCmd.PersistentFlags().Bool("allow-custom-extensions", false, "Whether to allow and copy custom request extensions into the signed timestamp")
+
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,9 +20,12 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"encoding/asn1"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -34,12 +37,30 @@ import (
 )
 
 type API struct {
-	tsaSigner     crypto.Signer       // the signer to use for timestamping
-	tsaSignerHash crypto.Hash         // hash algorithm used to hash pre-signed timestamps
-	certChain     []*x509.Certificate // timestamping cert chain
-	certChainPem  string              // PEM encoded timestamping cert chain
-	includeChain  bool                // Whether to include the full issuing chain or just the leaf certificate
-	useHTTP201    bool                // Whether to use HTTP 201 Created instead of HTTP 200 OK for timestamp responses
+	tsaSigner             crypto.Signer           // the signer to use for timestamping
+	tsaSignerHash         crypto.Hash             // hash algorithm used to hash pre-signed timestamps
+	certChain             []*x509.Certificate     // timestamping cert chain
+	certChainPem          string                  // PEM encoded timestamping cert chain
+	includeChain          bool                    // Whether to include the full issuing chain or just the leaf certificate
+	useHTTP201            bool                    // Whether to use HTTP 201 Created instead of HTTP 200 OK for timestamp responses
+	defaultPolicyOID      asn1.ObjectIdentifier   // Default policy OID to use if none is specified in the request
+	acceptedPolicyOIDs    []asn1.ObjectIdentifier // List of policy OIDs accepted in timestamp requests
+	allowCustomExtensions bool                    // Whether to allow and copy custom request extensions into the signed timestamp
+}
+
+func parseOID(oidStr string) (asn1.ObjectIdentifier, error) {
+	var oid asn1.ObjectIdentifier
+	if c := strings.Count(oidStr, "."); c > 128 {
+		return nil, fmt.Errorf("oid has too many sub identifiers")
+	}
+	for _, v := range strings.SplitN(oidStr, ".", 129) {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OID component %q: %w", v, err)
+		}
+		oid = append(oid, i)
+	}
+	return oid, nil
 }
 
 func NewAPI() (*API, error) {
@@ -88,13 +109,31 @@ func NewAPI() (*API, error) {
 		return nil, fmt.Errorf("marshal certificates to PEM: %w", err)
 	}
 
+	defaultPolicyOIDStr := viper.GetString("default-policy-oid")
+	defaultPolicyOID, err := parseOID(defaultPolicyOIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse default policy OID %q: %w", defaultPolicyOIDStr, err)
+	}
+
+	var acceptedPolicyOIDs []asn1.ObjectIdentifier
+	for _, oidStr := range viper.GetStringSlice("accepted-policy-oids") {
+		oid, err := parseOID(oidStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse accepted policy OID %q: %w", oidStr, err)
+		}
+		acceptedPolicyOIDs = append(acceptedPolicyOIDs, oid)
+	}
+
 	return &API{
-		tsaSigner:     tsaSigner,
-		tsaSignerHash: tsaSignerHash,
-		certChain:     certChain,
-		certChainPem:  string(certChainPEM),
-		includeChain:  viper.GetBool("include-chain-in-response"),
-		useHTTP201:    viper.GetBool("use-http-201"),
+		tsaSigner:             tsaSigner,
+		tsaSignerHash:         tsaSignerHash,
+		certChain:             certChain,
+		certChainPem:          string(certChainPEM),
+		includeChain:          viper.GetBool("include-chain-in-response"),
+		useHTTP201:            viper.GetBool("use-http-201"),
+		defaultPolicyOID:      defaultPolicyOID,
+		acceptedPolicyOIDs:    acceptedPolicyOIDs,
+		allowCustomExtensions: viper.GetBool("allow-custom-extensions"),
 	}, nil
 }
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -32,6 +32,8 @@ const (
 	excesssivelyLongOID                      = "OID should be comprised of at most 128 components"
 	WeakHashAlgorithmTimestampRequest        = "Weak hash algorithm in timestamp request"
 	InconsistentDigestLengthTimestampRequest = "Message digest has incorrect length for specified algorithm"
+	UnacceptedPolicyTimestampRequest         = "unaccepted policy: requested TSA policy is not supported by the TSA"
+	UnacceptedExtensionTimestampRequest      = "unaccepted extension: requested extensions are not supported by the TSA"
 )
 
 func errorMsg(message string, code int) *models.Error {

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -17,14 +17,13 @@ package api
 import (
 	"bytes"
 	"crypto"
-	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
 	"net/http"
-	"strconv"
+	"slices"
 	"strings"
 	"time"
 
@@ -78,14 +77,10 @@ func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 	if req.TSAPolicyOID == "" {
 		oidInts = nil
 	} else {
-		// 128 is the max number of sub-identifiers per
-		// https://datatracker.ietf.org/doc/html/rfc2578#section-3.5
-		if c := strings.Count(req.TSAPolicyOID, "."); c > 128 {
-			return nil, excesssivelyLongOID, fmt.Errorf("oid has %d sub identifiers, expected 128", c)
-		}
-		for _, v := range strings.SplitN(req.TSAPolicyOID, ".", 129) {
-			i, _ := strconv.Atoi(v)
-			oidInts = append(oidInts, i)
+		var err error
+		oidInts, err = parseOID(req.TSAPolicyOID)
+		if err != nil {
+			return nil, excesssivelyLongOID, err
 		}
 	}
 
@@ -157,7 +152,7 @@ func TimestampResponseHandler(params ts.GetTimestampResponseParams) middleware.R
 
 	policyID := req.TSAPolicyOID
 	if policyID.String() == "" {
-		policyID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 2}
+		policyID = api.defaultPolicyOID
 	}
 
 	duration, _ := time.ParseDuration("1s")
@@ -213,6 +208,17 @@ func verifyTimestampRequest(tsReq *timestamp.Request) (*timestamp.Request, strin
 			return nil, InconsistentDigestLengthTimestampRequest, err
 		}
 		return nil, failedToGenerateTimestampResponse, err
+	}
+
+	if len(tsReq.TSAPolicyOID) > 0 {
+		matched := slices.ContainsFunc(api.acceptedPolicyOIDs, tsReq.TSAPolicyOID.Equal)
+		if !matched {
+			return nil, UnacceptedPolicyTimestampRequest, verification.ErrUnacceptedPolicy
+		}
+	}
+
+	if !api.allowCustomExtensions && len(tsReq.Extensions) > 0 {
+		return nil, UnacceptedExtensionTimestampRequest, verification.ErrUnacceptedExtension
 	}
 
 	return tsReq, "", nil

--- a/pkg/generated/restapi/configure_timestamp_server.go
+++ b/pkg/generated/restapi/configure_timestamp_server.go
@@ -135,7 +135,7 @@ func limitRequestBody(next http.Handler) http.Handler {
 			if maxRequestBodySize > uint64(math.MaxInt64) {
 				log.Logger.Fatalf("max-request-body-size (%v) exceeds supported maximum (%v)", maxRequestBodySize, maxInt64Limit)
 			}
-			// #nosec G115
+			// #nosec G115 - checked above to ensure no overflow
 			r.Body = http.MaxBytesReader(w, r.Body, int64(maxRequestBodySize))
 		} else {
 			log.Logger.Debug("max-request-body-size is set to 0; no limit will be enforced on request body sizes")

--- a/pkg/tests/api_test.go
+++ b/pkg/tests/api_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"math/big"
@@ -267,60 +268,124 @@ func TestGetTimestampResponseWithExtsAndOID(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		url := createServer(t)
+		t.Run(tc.name+" Default Deny", func(t *testing.T) {
+			url := createServer(t)
 
-		c, err := client.GetTimestampClient(url, client.WithContentType(tc.reqMediaType))
-		if err != nil {
-			t.Fatalf("test '%s': unexpected error creating client: %v", tc.name, err)
-		}
-
-		// populate additional request parameters for extensions and OID - atypical request structure
-		var req *ts.Request
-		if tc.reqMediaType == client.TimestampQueryMediaType {
-			req, err = ts.ParseRequest(tc.reqBytes)
+			c, err := client.GetTimestampClient(url, client.WithContentType(tc.reqMediaType))
 			if err != nil {
-				t.Fatalf("test '%s': unexpected error parsing request: %v", tc.name, err)
+				t.Fatalf("unexpected error creating client: %v", err)
 			}
-		} else {
-			req, _, err = api.ParseJSONRequest(tc.reqBytes)
+
+			// populate additional request parameters for extensions and OID - atypical request structure
+			var req *ts.Request
+			if tc.reqMediaType == client.TimestampQueryMediaType {
+				req, err = ts.ParseRequest(tc.reqBytes)
+				if err != nil {
+					t.Fatalf("unexpected error parsing request: %v", err)
+				}
+			} else {
+				var jsonReq api.JSONRequest
+				if err := json.Unmarshal(tc.reqBytes, &jsonReq); err != nil {
+					t.Fatalf("unexpected error unmarshalling request: %v", err)
+				}
+				decoded, _ := base64.StdEncoding.DecodeString(jsonReq.ArtifactHash)
+				req = &ts.Request{
+					HashAlgorithm: crypto.SHA256,
+					HashedMessage: decoded,
+					Certificates:  jsonReq.Certificates,
+					Nonce:         jsonReq.Nonce,
+				}
+			}
+			req.ExtraExtensions = []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte{1, 2, 3, 4}}}
+			fakePolicyOID := asn1.ObjectIdentifier{1, 2, 3, 4, 5}
+			req.TSAPolicyOID = fakePolicyOID
+			tsq, err := req.Marshal()
 			if err != nil {
-				t.Fatalf("test '%s': unexpected error parsing request: %v", tc.name, err)
+				t.Fatalf("unexpected error creating request: %v", err)
 			}
-		}
-		req.ExtraExtensions = []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte{1, 2, 3, 4}}}
-		fakePolicyOID := asn1.ObjectIdentifier{1, 2, 3, 4, 5}
-		req.TSAPolicyOID = fakePolicyOID
-		tsq, err := req.Marshal()
-		if err != nil {
-			t.Fatalf("test '%s': unexpected error creating request: %v", tc.name, err)
-		}
 
-		params := timestamp.NewGetTimestampResponseParams()
-		params.SetTimeout(10 * time.Second)
-		params.Request = io.NopCloser(bytes.NewReader(tsq))
+			params := timestamp.NewGetTimestampResponseParams()
+			params.SetTimeout(10 * time.Second)
+			params.Request = io.NopCloser(bytes.NewReader(tsq))
 
-		var respBytes bytes.Buffer
-		clientOption := func(op *runtime.ClientOperation) {
-			op.ConsumesMediaTypes = []string{client.TimestampQueryMediaType}
-		}
-		_, _, err = c.Timestamp.GetTimestampResponse(params, &respBytes, clientOption)
-		if err != nil {
-			t.Fatalf("test '%s': unexpected error getting timestamp response: %v", tc.name, err)
-		}
+			var respBytes bytes.Buffer
+			clientOption := func(op *runtime.ClientOperation) {
+				op.ConsumesMediaTypes = []string{client.TimestampQueryMediaType}
+			}
+			_, _, err = c.Timestamp.GetTimestampResponse(params, &respBytes, clientOption)
+			if err == nil {
+				t.Fatalf("expected error when requesting unaccepted policy/extensions")
+			}
+			if !strings.Contains(err.Error(), "unaccepted policy") {
+				t.Fatalf("expected unaccepted policy error, got: %v", err)
+			}
+		})
 
-		tsr, err := ts.ParseResponse(respBytes.Bytes())
-		if err != nil {
-			t.Fatalf("test '%s': unexpected error parsing response: %v", tc.name, err)
-		}
+		t.Run(tc.name+" Allowed via Config", func(t *testing.T) {
+			url := createServer(t, func() {
+				viper.Set("accepted-policy-oids", []string{"1.3.6.1.4.1.57264.2", "1.2.3.4.5"})
+				viper.Set("allow-custom-extensions", true)
+			})
 
-		// check policy OID
-		if !tsr.Policy.Equal(fakePolicyOID) {
-			t.Fatalf("test '%s': unexpected policy ID", tc.name)
-		}
-		// check extension is present
-		if len(tsr.Extensions) != 1 {
-			t.Fatalf("test '%s': expected 1 extension, got %d", tc.name, len(tsr.Extensions))
-		}
+			c, err := client.GetTimestampClient(url, client.WithContentType(tc.reqMediaType))
+			if err != nil {
+				t.Fatalf("unexpected error creating client: %v", err)
+			}
+
+			var req *ts.Request
+			if tc.reqMediaType == client.TimestampQueryMediaType {
+				req, err = ts.ParseRequest(tc.reqBytes)
+				if err != nil {
+					t.Fatalf("unexpected error parsing request: %v", err)
+				}
+			} else {
+				var jsonReq api.JSONRequest
+				if err := json.Unmarshal(tc.reqBytes, &jsonReq); err != nil {
+					t.Fatalf("unexpected error unmarshalling request: %v", err)
+				}
+				decoded, _ := base64.StdEncoding.DecodeString(jsonReq.ArtifactHash)
+				req = &ts.Request{
+					HashAlgorithm: crypto.SHA256,
+					HashedMessage: decoded,
+					Certificates:  jsonReq.Certificates,
+					Nonce:         jsonReq.Nonce,
+				}
+			}
+			req.ExtraExtensions = []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte{1, 2, 3, 4}}}
+			fakePolicyOID := asn1.ObjectIdentifier{1, 2, 3, 4, 5}
+			req.TSAPolicyOID = fakePolicyOID
+			tsq, err := req.Marshal()
+			if err != nil {
+				t.Fatalf("unexpected error creating request: %v", err)
+			}
+
+			params := timestamp.NewGetTimestampResponseParams()
+			params.SetTimeout(10 * time.Second)
+			params.Request = io.NopCloser(bytes.NewReader(tsq))
+
+			var respBytes bytes.Buffer
+			clientOption := func(op *runtime.ClientOperation) {
+				op.ConsumesMediaTypes = []string{client.TimestampQueryMediaType}
+			}
+			_, _, err = c.Timestamp.GetTimestampResponse(params, &respBytes, clientOption)
+			if err != nil {
+				t.Fatalf("unexpected error getting timestamp response: %v", err)
+			}
+
+			tsr, err := ts.ParseResponse(respBytes.Bytes())
+			if err != nil {
+				t.Fatalf("unexpected error parsing response: %v", err)
+			}
+
+			// check policy OID
+			if !tsr.Policy.Equal(fakePolicyOID) {
+				t.Fatalf("unexpected policy ID")
+			}
+			// check extension is present
+			if len(tsr.Extensions) != 1 {
+				t.Fatalf("expected 1 extension, got %d", len(tsr.Extensions))
+			}
+		})
 	}
 }
 
@@ -329,7 +394,7 @@ func TestGetTimestampResponseWithNoCertificateOrNonce(t *testing.T) {
 	includeCerts := false
 	hashFunc := crypto.SHA256
 	hashName := "sha256"
-	oidStr := "1.2.3.4"
+	oidStr := "1.3.6.1.4.1.57264.2"
 
 	opts := ts.RequestOptions{
 		Certificates: includeCerts,

--- a/pkg/tests/server.go
+++ b/pkg/tests/server.go
@@ -29,6 +29,9 @@ import (
 func createServer(t *testing.T, flagsToSet ...func()) string {
 	viper.Set("timestamp-signer", "memory")
 	viper.Set("timestamp-signer-hash", "sha256")
+	viper.Set("accepted-policy-oids", []string{"1.3.6.1.4.1.57264.2"})
+	viper.Set("allow-custom-extensions", false)
+	viper.Set("default-policy-oid", "1.3.6.1.4.1.57264.2")
 	for _, flag := range flagsToSet {
 		flag()
 	}

--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -17,6 +17,7 @@ package verification
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
@@ -96,7 +97,7 @@ func verifyLeafCertCriticalEKU(cert *x509.Certificate) error {
 	return nil
 }
 
-func verifyLeafCert(leafCert *x509.Certificate, opts VerifyOpts) error {
+func verifyLeafCert(leafCert *x509.Certificate, verifiedChains [][]*x509.Certificate, opts VerifyOpts) error {
 	if leafCert == nil {
 		// should never happen
 		return fmt.Errorf("signer certificate is required")
@@ -121,7 +122,7 @@ func verifyLeafCert(leafCert *x509.Certificate, opts VerifyOpts) error {
 
 	// verifies that the leaf certificate and any intermediate certificates
 	// have EKU set to only time stamping usage
-	err = verifyLeafAndIntermediatesTimestampingEKU(leafCert, opts)
+	err = verifyLeafAndIntermediatesTimestampingEKU(leafCert, verifiedChains)
 	if err != nil {
 		return fmt.Errorf("failed to verify EKU on leaf certificate: %w", err)
 	}
@@ -167,17 +168,30 @@ func verifyIntermediateExtendedKeyUsage(cert *x509.Certificate) error {
 // Leaf certificates must have exactly one EKU set to Timestamping
 // Intermediates can have no EKU (unrestricted) or multiple EKUs,
 // which need to include Timestamping or UsageAny.
-func verifyLeafAndIntermediatesTimestampingEKU(leafCert *x509.Certificate, opts VerifyOpts) error {
+func verifyLeafAndIntermediatesTimestampingEKU(leafCert *x509.Certificate, verifiedChains [][]*x509.Certificate) error {
 	err := verifyLeafExtendedKeyUsage(leafCert)
 	if err != nil {
 		return fmt.Errorf("failed to verify EKU on leaf certificate: %w", err)
 	}
 
-	for _, cert := range opts.Intermediates {
-		err := verifyIntermediateExtendedKeyUsage(cert)
-		if err != nil {
-			return fmt.Errorf("failed to verify EKU on intermediate certificate: %w", err)
+	var lastErr error
+	for _, chain := range verifiedChains {
+		chainOK := true
+		// Skip the leaf cert (index 0) and the root (last index)
+		for i := 1; i < len(chain)-1; i++ {
+			err := verifyIntermediateExtendedKeyUsage(chain[i])
+			if err != nil {
+				chainOK = false
+				lastErr = err
+				break
+			}
 		}
+		if chainOK {
+			return nil // Found at least one fully valid chain with proper EKU chaining
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("no verified certificate chain met EKU requirements: %w", lastErr)
 	}
 	return nil
 }
@@ -224,8 +238,16 @@ func VerifyTimestampResponse(tsrBytes []byte, artifact io.Reader, opts VerifyOpt
 		return nil, fmt.Errorf("error parsing response into Timestamp: %w", err)
 	}
 
+	switch ts.HashAlgorithm {
+	case crypto.SHA1:
+		return nil, ErrWeakHashAlg
+	case crypto.SHA256, crypto.SHA384, crypto.SHA512:
+	default:
+		return nil, ErrUnsupportedHashAlg
+	}
+
 	// verify the timestamp response signature using the provided certificate pool
-	signerCert, err := verifyTSRWithChain(ts, opts)
+	signerCert, verifiedChains, err := verifyTSRWithChain(ts, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +260,7 @@ func VerifyTimestampResponse(tsrBytes []byte, artifact io.Reader, opts VerifyOpt
 		return nil, err
 	}
 
-	if err = verifyLeafCert(signerCert, opts); err != nil {
+	if err = verifyLeafCert(signerCert, verifiedChains, opts); err != nil {
 		return nil, err
 	}
 
@@ -252,18 +274,18 @@ func VerifyTimestampResponse(tsrBytes []byte, artifact io.Reader, opts VerifyOpt
 }
 
 // Returns the TSA signer certificate after verifying the certificate chain validity.
-func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certificate, error) {
+func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certificate, [][]*x509.Certificate, error) {
 	p7Message, err := pkcs7.Parse(ts.RawToken)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing hashed message: %w", err)
+		return nil, nil, fmt.Errorf("error parsing hashed message: %w", err)
 	}
 
 	if len(opts.Roots) == 0 {
-		return nil, fmt.Errorf("no root certificates provided for verifying the certificate chain")
+		return nil, nil, fmt.Errorf("no root certificates provided for verifying the certificate chain")
 	}
 
 	if p7Message.Certificates == nil && opts.TSACertificate == nil {
-		return nil, fmt.Errorf("leaf certificate must be present in the TSR or as a verify option")
+		return nil, nil, fmt.Errorf("leaf certificate must be present in the TSR or as a verify option")
 	}
 
 	rootCertPool := x509.NewCertPool()
@@ -273,10 +295,15 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certifi
 		}
 	}
 	if rootCertPool.Equal(x509.NewCertPool()) {
-		return nil, fmt.Errorf("no valid root certificates provided for verifying the certificate chain")
+		return nil, nil, fmt.Errorf("no valid root certificates provided for verifying the certificate chain")
 	}
 	intermediateCertPool := x509.NewCertPool()
 	for _, cert := range opts.Intermediates {
+		if cert != nil {
+			intermediateCertPool.AddCert(cert)
+		}
+	}
+	for _, cert := range p7Message.Certificates {
 		if cert != nil {
 			intermediateCertPool.AddCert(cert)
 		}
@@ -285,6 +312,7 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certifi
 	x509Opts := x509.VerifyOptions{
 		Roots:         rootCertPool,
 		Intermediates: intermediateCertPool,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
 	}
 
 	// if the PCKS7 object does not have any certificates set in the
@@ -297,21 +325,26 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certifi
 		p7Message.Certificates = []*x509.Certificate{opts.TSACertificate}
 	}
 
-	err = p7Message.VerifyWithOpts(x509Opts)
+	err = p7Message.Verify()
 	if err != nil {
-		return nil, fmt.Errorf("error while verifying with chain: %w", err)
+		return nil, nil, fmt.Errorf("error while verifying signature: %w", err)
 	}
 
 	signerCert := p7Message.GetOnlySigner()
 	if signerCert == nil {
-		return nil, fmt.Errorf("signer certificate was not found")
+		return nil, nil, fmt.Errorf("signer certificate was not found")
 	}
 
 	if opts.TSACertificate != nil && !opts.TSACertificate.Equal(signerCert) {
-		return nil, fmt.Errorf("certificate embedded in the TSR does not match the provided TSA certificate")
+		return nil, nil, fmt.Errorf("certificate embedded in the TSR does not match the provided TSA certificate")
 	}
 
-	return signerCert, nil
+	chains, err := signerCert.Verify(x509Opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error while verifying signer certificate chain: %w", err)
+	}
+
+	return signerCert, chains, nil
 }
 
 // Verify that the TSR's hashed message matches the digest of the artifact to be timestamped

--- a/pkg/verification/verify_request.go
+++ b/pkg/verification/verify_request.go
@@ -25,6 +25,8 @@ import (
 var ErrWeakHashAlg = errors.New("weak hash algorithm: must be SHA-256, SHA-384, or SHA-512")
 var ErrUnsupportedHashAlg = errors.New("unsupported hash algorithm")
 var ErrInconsistentDigestLength = errors.New("digest length inconsistent with specified hash algorithm")
+var ErrUnacceptedPolicy = errors.New("unaccepted policy: requested TSA policy is not supported by the TSA")
+var ErrUnacceptedExtension = errors.New("unaccepted extension: requested extensions are not supported by the TSA")
 
 func VerifyRequest(ts *timestamp.Request) error {
 	// only SHA-1, SHA-256, SHA-384, and SHA-512 are supported by the underlying library

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -258,7 +258,7 @@ func TestVerifyLeafCert(t *testing.T) {
 			ts.Certificates = []*x509.Certificate{sampleCert}
 		}
 
-		err := verifyLeafCert(testSigner, opts)
+		err := verifyLeafCert(testSigner, nil, opts)
 
 		if err != nil && tc.expectVerifySuccess {
 			t.Fatalf("expected error to be nil, actual error: %v", err)
@@ -674,7 +674,7 @@ func TestVerifyTSRWithChain(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err = verifyTSRWithChain(tc.ts, tc.opts)
+			_, _, err = verifyTSRWithChain(tc.ts, tc.opts)
 			if tc.expectVerifySuccess && err != nil {
 				t.Errorf("unexpectedly failed \nExpected verifyTSRWithChain to successfully verify certificate chain, err: %v", err)
 			} else if !tc.expectVerifySuccess && err == nil {
@@ -719,5 +719,81 @@ func TestVerifyTimestampResponseWithOutOfChainCert(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("VerifyTimestampResponse succeeded with a certificate that is not part of the cert chain.")
+	}
+}
+
+func TestVerifyLeafAndIntermediatesTimestampingEKU(t *testing.T) {
+	leaf := &x509.Certificate{
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+	}
+
+	intermediateAuthorized := &x509.Certificate{
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+	}
+
+	intermediateUnrestricted := &x509.Certificate{
+		ExtKeyUsage: []x509.ExtKeyUsage{},
+	}
+
+	intermediateUnauthorized := &x509.Certificate{
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	root := &x509.Certificate{}
+
+	tests := []struct {
+		name        string
+		chains      [][]*x509.Certificate
+		expectError bool
+	}{
+		{
+			name: "Single chain: Authorized Intermediate",
+			chains: [][]*x509.Certificate{
+				{leaf, intermediateAuthorized, root},
+			},
+			expectError: false,
+		},
+		{
+			name: "Single chain: Unrestricted Intermediate",
+			chains: [][]*x509.Certificate{
+				{leaf, intermediateUnrestricted, root},
+			},
+			expectError: false,
+		},
+		{
+			name: "Single chain: Unauthorized Intermediate",
+			chains: [][]*x509.Certificate{
+				{leaf, intermediateUnauthorized, root},
+			},
+			expectError: true,
+		},
+		{
+			name: "Multiple chains: One unauthorized, one authorized (Cross-signed CA scenario)",
+			chains: [][]*x509.Certificate{
+				{leaf, intermediateUnauthorized, root},
+				{leaf, intermediateAuthorized, root},
+			},
+			expectError: false,
+		},
+		{
+			name: "Multiple chains: All unauthorized",
+			chains: [][]*x509.Certificate{
+				{leaf, intermediateUnauthorized, root},
+				{leaf, intermediateUnauthorized, root},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyLeafAndIntermediatesTimestampingEKU(leaf, tc.chains)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
To prevent clients from specifying their own TSA policy OIDs, obtaining signatures over arbitrary extensions, and utilizing weak digests, this change:

* Introduces server flags for default/accepted policy OIDs and custom extensions
* Configures server-side validation to reject unauthorized policy OIDs and custom request extensions by default
* Updates client-side verification to build paths including TSR-embedded intermediates and enforce EKU chaining constraints on every intermediate CA
* Configures client-side verification to reject SHA-1, which is the server already does

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
