### PR TITLE
Validate TSA certificate chain at timestamp issuance time

### DIFF
--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -24,6 +24,7 @@ import (
 	"hash"
 	"io"
 	"math/big"
+	"time"
 
 	"github.com/digitorus/pkcs7"
 	"github.com/digitorus/timestamp"
@@ -51,6 +52,11 @@ type VerifyOpts struct {
 	Nonce *big.Int
 	// CommonName verifies that the TSR certificate subject's Common Name matches the expected value. Optional
 	CommonName string
+	// CurrentTime, if not zero, is used as the current time for certificate
+	// chain validation instead of time.Now. This is necessary when verifying
+	// timestamps after the TSA certificate has expired, since the timestamp
+	// was issued while the certificate was still valid.
+	CurrentTime time.Time
 }
 
 // Verify the TSR's certificate identifier matches a provided TSA certificate
@@ -246,6 +252,13 @@ func VerifyTimestampResponse(tsrBytes []byte, artifact io.Reader, opts VerifyOpt
 		return nil, ErrUnsupportedHashAlg
 	}
 
+	// Use the timestamp's own time for certificate chain validation when
+	// the caller hasn't specified one. The TSA certificate must have been
+	// valid when the timestamp was issued, not necessarily at the current time.
+	if opts.CurrentTime.IsZero() {
+		opts.CurrentTime = ts.Time
+	}
+
 	// verify the timestamp response signature using the provided certificate pool
 	signerCert, verifiedChains, err := verifyTSRWithChain(ts, opts)
 	if err != nil {
@@ -313,6 +326,7 @@ func verifyTSRWithChain(ts *timestamp.Timestamp, opts VerifyOpts) (*x509.Certifi
 		Roots:         rootCertPool,
 		Intermediates: intermediateCertPool,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		CurrentTime:   opts.CurrentTime,
 	}
 
 	// if the PCKS7 object does not have any certificates set in the

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -670,6 +670,36 @@ func TestVerifyTSRWithChain(t *testing.T) {
 			},
 			expectVerifySuccess: true,
 		},
+		{
+			name: "Verification succeeds with CurrentTime within cert validity",
+			ts:   tsWithCerts,
+			opts: VerifyOpts{
+				Roots:         []*x509.Certificate{root},
+				Intermediates: []*x509.Certificate{intermediate},
+				CurrentTime:   time.Now(),
+			},
+			expectVerifySuccess: true,
+		},
+		{
+			name: "Verification fails when CurrentTime is after cert expiry",
+			ts:   tsWithCerts,
+			opts: VerifyOpts{
+				Roots:         []*x509.Certificate{root},
+				Intermediates: []*x509.Certificate{intermediate},
+				CurrentTime:   time.Now().Add(20 * 365 * 24 * time.Hour),
+			},
+			expectVerifySuccess: false,
+		},
+		{
+			name: "Verification fails when CurrentTime is before cert validity",
+			ts:   tsWithCerts,
+			opts: VerifyOpts{
+				Roots:         []*x509.Certificate{root},
+				Intermediates: []*x509.Certificate{intermediate},
+				CurrentTime:   time.Now().Add(-24 * time.Hour),
+			},
+			expectVerifySuccess: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Validate the TSA certificate chain at the timestamp's `genTime` rather than at the current wall-clock time, so that verification succeeds even after the TSA certificate has expired
- Add `VerifyOpts.CurrentTime` to allow callers to override the validation time explicitly

## Motivation

Previously, `VerifyTimestampResponse` validated the TSA certificate chain using `time.Now()` (Go's default when `x509.VerifyOptions.CurrentTime` is zero). This caused verification to fail once the TSA signing certificate expired, even though the timestamp was issued while the certificate was still valid.

Per [RFC 3161](https://www.rfc-editor.org/rfc/rfc3161) Appendix B (steps B.4–B.5), the TSA certificate chain should be validated at the time the timestamp was issued (`genTime`), not at the time of verification. A timestamp token remains valid as long as the TSA certificate was valid and unrevoked at `genTime`.

This change defaults `CurrentTime` to `ts.Time` when the caller does not specify one, aligning certificate chain validation with the RFC 3161 verification model.