### PR TITLE
count unknown EKUs when enforcing single timestamping usage

### DIFF
--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -137,12 +137,15 @@ func verifyLeafCert(leafCert *x509.Certificate, verifiedChains [][]*x509.Certifi
 }
 
 func verifyLeafExtendedKeyUsage(cert *x509.Certificate) error {
-	certEKULen := len(cert.ExtKeyUsage)
+	// crypto/x509 sorts key purposes it does not recognise into
+	// UnknownExtKeyUsage, so a leaf carrying id-kp-timeStamping alongside an
+	// unknown OID would otherwise pass the single-EKU requirement of RFC 3161 2.3.
+	certEKULen := len(cert.ExtKeyUsage) + len(cert.UnknownExtKeyUsage)
 	if certEKULen != 1 {
 		return fmt.Errorf("certificate has %d extended key usages, expected only one", certEKULen)
 	}
 
-	if cert.ExtKeyUsage[0] != x509.ExtKeyUsageTimeStamping {
+	if len(cert.ExtKeyUsage) != 1 || cert.ExtKeyUsage[0] != x509.ExtKeyUsageTimeStamping {
 		return fmt.Errorf("leaf certificate EKU is not set to TimeStamping as required")
 	}
 	return nil

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -410,6 +410,7 @@ func TestVerifyESSCertID(t *testing.T) {
 func TestVerifyLeafExtendedKeyUsage(t *testing.T) {
 	type test struct {
 		eku                 []x509.ExtKeyUsage
+		unknownEKU          []asn1.ObjectIdentifier
 		expectVerifySuccess bool
 	}
 
@@ -426,11 +427,24 @@ func TestVerifyLeafExtendedKeyUsage(t *testing.T) {
 			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageIPSECTunnel},
 			expectVerifySuccess: false,
 		},
+		{
+			// timestamping plus an unrecognised key purpose OID, which
+			// crypto/x509 records under UnknownExtKeyUsage
+			eku:                 []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+			unknownEKU:          []asn1.ObjectIdentifier{{1, 2, 3, 4, 5}},
+			expectVerifySuccess: false,
+		},
+		{
+			// only an unrecognised key purpose, no timestamping
+			unknownEKU:          []asn1.ObjectIdentifier{{1, 2, 3, 4, 5}},
+			expectVerifySuccess: false,
+		},
 	}
 
 	for _, tc := range tests {
 		cert := x509.Certificate{
-			ExtKeyUsage: tc.eku,
+			ExtKeyUsage:        tc.eku,
+			UnknownExtKeyUsage: tc.unknownEKU,
 		}
 
 		err := verifyLeafExtendedKeyUsage(&cert)

--- a/pkg/x509/x509.go
+++ b/pkg/x509/x509.go
@@ -78,9 +78,9 @@ func VerifyCertChain(certs []*x509.Certificate, signer crypto.Signer, enforceInt
 	}
 
 	// Verify leaf has only a single EKU for timestamping, per RFC 3161 2.3
-	// This should be enforced by Verify already
-	leafEKU := leaf.ExtKeyUsage
-	if len(leafEKU) != 1 {
+	// This should be enforced by Verify already. Key purposes that crypto/x509
+	// does not recognise land in UnknownExtKeyUsage, so count those too.
+	if len(leaf.ExtKeyUsage)+len(leaf.UnknownExtKeyUsage) != 1 {
 		return errors.New("certificate should only contain one EKU")
 	}
 

--- a/pkg/x509/x509_test.go
+++ b/pkg/x509/x509_test.go
@@ -16,6 +16,7 @@ package x509
 
 import (
 	"crypto/x509"
+	"encoding/asn1"
 	"strings"
 	"testing"
 
@@ -55,5 +56,12 @@ func TestVerifyCertChain(t *testing.T) {
 	// failure: mismatched public key
 	if err := VerifyCertChain([]*x509.Certificate{leafCert, subCert, rootCert}, leafFromRootKey, true); err == nil || !strings.Contains(err.Error(), "public keys are not equal") {
 		t.Fatalf("expected failure verifying certificate chain: %v", err)
+	}
+
+	// failure: leaf carries an extra unrecognised EKU beyond timestamping, per RFC 3161 2.3
+	extraEKULeaf, extraEKUKey, _ := testutils.GenerateLeafCert(subCert, subKey)
+	extraEKULeaf.UnknownExtKeyUsage = []asn1.ObjectIdentifier{{1, 2, 3, 4, 5}}
+	if err := VerifyCertChain([]*x509.Certificate{extraEKULeaf, subCert, rootCert}, extraEKUKey, true); err == nil || !strings.Contains(err.Error(), "should only contain one EKU") {
+		t.Fatalf("expected failure verifying certificate chain with extra EKU: %v", err)
 	}
 }


### PR DESCRIPTION
the leaf eku check enforces rfc 3161 2.3's single timestamping usage by counting cert.ExtKeyUsage, but crypto/x509 records key purposes it doesn't recognise under UnknownExtKeyUsage, so a tsa leaf carrying id-kp-timeStamping plus an unknown eku oid is accepted as a timestamping certificate both when verifying a response and when validating the configured chain. that lets a broader multi-purpose certificate stand in where the spec wants a timestamping-only one. count the known and unknown key purposes together at both sites so only a leaf with exactly the one usage is allowed.