### PR TITLE
bound json nonce length before parsing in parsejsonrequest

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -30,7 +30,7 @@ import (
 const (
 	failedToGenerateTimestampResponse        = "Error generating timestamp response"
 	excesssivelyLongOID                      = "OID should be comprised of at most 128 components"
-	excessivelyLongNonce                     = "nonce in timestamp request is too large"
+	excessivelyLargeRequest                  = "timestamp request is too large"
 	WeakHashAlgorithmTimestampRequest        = "Weak hash algorithm in timestamp request"
 	InconsistentDigestLengthTimestampRequest = "Message digest has incorrect length for specified algorithm"
 	UnacceptedPolicyTimestampRequest         = "unaccepted policy: requested TSA policy is not supported by the TSA"

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -30,6 +30,7 @@ import (
 const (
 	failedToGenerateTimestampResponse        = "Error generating timestamp response"
 	excesssivelyLongOID                      = "OID should be comprised of at most 128 components"
+	excessivelyLongNonce                     = "nonce in timestamp request is too large"
 	WeakHashAlgorithmTimestampRequest        = "Weak hash algorithm in timestamp request"
 	InconsistentDigestLengthTimestampRequest = "Message digest has incorrect length for specified algorithm"
 	UnacceptedPolicyTimestampRequest         = "unaccepted policy: requested TSA policy is not supported by the TSA"

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -42,13 +42,15 @@ type JSONRequest struct {
 	TSAPolicyOID  string   `json:"tsaPolicyOID"`
 }
 
-// maxJSONNonceBytes bounds the length of the JSON-encoded nonce before it is
-// decoded into a big.Int. RFC 3161 nonces are small random values, but parsing
-// a base-10 integer is quadratic in the number of digits, so an unbounded
-// decimal nonce lets a single request burn a disproportionate amount of CPU.
-// The DER request path is unaffected because ASN.1 INTEGERs are decoded from
-// their binary representation.
-const maxJSONNonceBytes = 1024
+// maxJSONRequestBytes bounds the size of a JSON timestamp request before it is
+// parsed. The artifact hash, hash algorithm and policy OID are all small fixed
+// fields, so the only field that can grow without limit is the nonce, which is
+// decoded into a big.Int. Parsing a base-10 integer is quadratic in the number
+// of digits, so an unbounded decimal nonce lets a single request burn a
+// disproportionate amount of CPU. 1KB leaves ample room for a real request
+// while rejecting the oversized case up front. The DER request path is
+// unaffected because ASN.1 INTEGERs are decoded from their binary form.
+const maxJSONRequestBytes = 1024
 
 func getHashAlg(alg string) (crypto.Hash, string, error) {
 	lowercaseAlg := strings.ToLower(alg)
@@ -68,18 +70,11 @@ func getHashAlg(alg string) (crypto.Hash, string, error) {
 
 // ParseJSONRequest parses a JSON request into a timestamp.Request struct
 func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
-	// Bound the nonce length before it is decoded into a big.Int. The raw
-	// nonce is captured without parsing it (decoding a base-10 integer is
-	// quadratic in its digit count) so an oversized decimal nonce is rejected
-	// before that cost is paid.
-	var nonceProbe struct {
-		Nonce json.RawMessage `json:"nonce"`
-	}
-	if err := json.Unmarshal(reqBytes, &nonceProbe); err != nil {
-		return nil, failedToGenerateTimestampResponse, fmt.Errorf("failed to parse JSON into request: %v", err)
-	}
-	if len(nonceProbe.Nonce) > maxJSONNonceBytes {
-		return nil, excessivelyLongNonce, fmt.Errorf("nonce exceeds %d bytes", maxJSONNonceBytes)
+	// Reject oversized requests before parsing. The only field that can grow
+	// unbounded is the nonce, which is decoded into a big.Int at quadratic
+	// cost, so cap the whole request rather than singling out the nonce.
+	if len(reqBytes) > maxJSONRequestBytes {
+		return nil, excessivelyLargeRequest, fmt.Errorf("request exceeds %d bytes", maxJSONRequestBytes)
 	}
 
 	// unmarshal the request bytes into a JSONRequest struct

--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -42,6 +42,14 @@ type JSONRequest struct {
 	TSAPolicyOID  string   `json:"tsaPolicyOID"`
 }
 
+// maxJSONNonceBytes bounds the length of the JSON-encoded nonce before it is
+// decoded into a big.Int. RFC 3161 nonces are small random values, but parsing
+// a base-10 integer is quadratic in the number of digits, so an unbounded
+// decimal nonce lets a single request burn a disproportionate amount of CPU.
+// The DER request path is unaffected because ASN.1 INTEGERs are decoded from
+// their binary representation.
+const maxJSONNonceBytes = 1024
+
 func getHashAlg(alg string) (crypto.Hash, string, error) {
 	lowercaseAlg := strings.ToLower(alg)
 	switch lowercaseAlg {
@@ -60,6 +68,20 @@ func getHashAlg(alg string) (crypto.Hash, string, error) {
 
 // ParseJSONRequest parses a JSON request into a timestamp.Request struct
 func ParseJSONRequest(reqBytes []byte) (*timestamp.Request, string, error) {
+	// Bound the nonce length before it is decoded into a big.Int. The raw
+	// nonce is captured without parsing it (decoding a base-10 integer is
+	// quadratic in its digit count) so an oversized decimal nonce is rejected
+	// before that cost is paid.
+	var nonceProbe struct {
+		Nonce json.RawMessage `json:"nonce"`
+	}
+	if err := json.Unmarshal(reqBytes, &nonceProbe); err != nil {
+		return nil, failedToGenerateTimestampResponse, fmt.Errorf("failed to parse JSON into request: %v", err)
+	}
+	if len(nonceProbe.Nonce) > maxJSONNonceBytes {
+		return nil, excessivelyLongNonce, fmt.Errorf("nonce exceeds %d bytes", maxJSONNonceBytes)
+	}
+
 	// unmarshal the request bytes into a JSONRequest struct
 	var req JSONRequest
 	if err := json.Unmarshal(reqBytes, &req); err != nil {

--- a/pkg/api/timestamp_test.go
+++ b/pkg/api/timestamp_test.go
@@ -14,7 +14,13 @@
 
 package api
 
-import "testing"
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
 
 func FuzzParseJSONRequest(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, reqBytes []byte) {
@@ -26,4 +32,24 @@ func FuzzParseDERRequest(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, reqBytes []byte) {
 		_, _, _ = parseDERRequest(reqBytes)
 	})
+}
+
+func TestParseJSONRequestRejectsOversizeNonce(t *testing.T) {
+	hash := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	digits := strings.Repeat("9", 200000)
+	body := []byte(fmt.Sprintf(`{"artifactHash":%q,"hashAlgorithm":"sha256","nonce":%s}`, hash, digits))
+
+	start := time.Now()
+	_, msg, err := ParseJSONRequest(body)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected oversize nonce to be rejected")
+	}
+	if msg != excessivelyLongNonce {
+		t.Fatalf("expected message %q, got %q", excessivelyLongNonce, msg)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("rejection took too long (%v), nonce was parsed before the bound check", elapsed)
+	}
 }

--- a/pkg/api/timestamp_test.go
+++ b/pkg/api/timestamp_test.go
@@ -34,7 +34,7 @@ func FuzzParseDERRequest(f *testing.F) {
 	})
 }
 
-func TestParseJSONRequestRejectsOversizeNonce(t *testing.T) {
+func TestParseJSONRequestRejectsOversizeRequest(t *testing.T) {
 	hash := base64.StdEncoding.EncodeToString(make([]byte, 32))
 	digits := strings.Repeat("9", 200000)
 	body := []byte(fmt.Sprintf(`{"artifactHash":%q,"hashAlgorithm":"sha256","nonce":%s}`, hash, digits))
@@ -44,12 +44,12 @@ func TestParseJSONRequestRejectsOversizeNonce(t *testing.T) {
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Fatal("expected oversize nonce to be rejected")
+		t.Fatal("expected oversize request to be rejected")
 	}
-	if msg != excessivelyLongNonce {
-		t.Fatalf("expected message %q, got %q", excessivelyLongNonce, msg)
+	if msg != excessivelyLargeRequest {
+		t.Fatalf("expected message %q, got %q", excessivelyLargeRequest, msg)
 	}
 	if elapsed > 100*time.Millisecond {
-		t.Fatalf("rejection took too long (%v), nonce was parsed before the bound check", elapsed)
+		t.Fatalf("rejection took too long (%v), request was parsed before the size check", elapsed)
 	}
 }


### PR DESCRIPTION
**Quadratic nonce parsing on the JSON timestamp endpoint**

The JSON branch of `/api/v1/timestamp` decodes the request's nonce straight into a big.Int, and base-10 integer parsing is quadratic in the digit count. Because the endpoint is reachable before any authentication, a request carrying a long decimal nonce (comfortably inside the default 1MB body limit) ties up a fair amount of CPU: a 200k-digit nonce already costs roughly 30ms and the cost grows with the square of the length, so a body near the limit reaches several hundred milliseconds per request. The timestamp-query (DER) path is not affected because ASN.1 integers are read from their binary form, which is linear.

The artifact hash, hash algorithm and policy OID are all small fixed fields, so the only thing that can grow without limit is the nonce. Rather than singling out the nonce, the change caps the whole JSON request at 1KB before parsing, which leaves ample room for a real request and rejects the oversized case up front.