### PR TITLE
reject timestamp response missing the requested nonce

### DIFF
--- a/pkg/verification/verify.go
+++ b/pkg/verification/verify.go
@@ -227,6 +227,14 @@ func verifyNonce(requestNonce *big.Int, opts VerifyOpts) error {
 	if opts.Nonce == nil {
 		return nil
 	}
+	// A nonce was requested, so per RFC 3161 2.4.2 the response must carry the
+	// same nonce. The nonce is optional in the response structure, so a
+	// (genuinely signed) response that drops it must be rejected rather than
+	// dereferenced, otherwise a replayed timestamp lacking the nonce trips a
+	// nil pointer in the comparison below.
+	if requestNonce == nil {
+		return fmt.Errorf("expected nonce %d but response does not contain a nonce", opts.Nonce)
+	}
 	if opts.Nonce.Cmp(requestNonce) != 0 {
 		return fmt.Errorf("incoming nonce %d does not match TSR nonce %d", requestNonce, opts.Nonce)
 	}

--- a/pkg/verification/verify_test.go
+++ b/pkg/verification/verify_test.go
@@ -141,6 +141,7 @@ func TestVerifyArtifactHashedMessages(t *testing.T) {
 func TestVerifyNonce(t *testing.T) {
 	type test struct {
 		nonceStr            string
+		missingNonce        bool
 		expectVerifySuccess bool
 	}
 
@@ -151,6 +152,12 @@ func TestVerifyNonce(t *testing.T) {
 		},
 		{
 			nonceStr:            "9874325235234314241230",
+			expectVerifySuccess: false,
+		},
+		{
+			// A nonce was requested but the response omits it. This must be
+			// rejected rather than panicking on the nil comparison.
+			missingNonce:        true,
 			expectVerifySuccess: false,
 		},
 	}
@@ -165,9 +172,12 @@ func TestVerifyNonce(t *testing.T) {
 			Nonce: optsNonce,
 		}
 
-		providedNonce, ok := new(big.Int).SetString(tc.nonceStr, 10)
-		if !ok {
-			t.Fatalf("unexpected failure to create big int from string: %s", tc.nonceStr)
+		var providedNonce *big.Int
+		if !tc.missingNonce {
+			providedNonce, ok = new(big.Int).SetString(tc.nonceStr, 10)
+			if !ok {
+				t.Fatalf("unexpected failure to create big int from string: %s", tc.nonceStr)
+			}
 		}
 
 		err := verifyNonce(providedNonce, opts)


### PR DESCRIPTION
verifyNonce compares the caller's expected nonce against the nonce parsed from the response, but the nonce is optional in an RFC 3161 reply, so a validly signed response that omits it leaves the parsed value nil and the comparison panics once a caller has requested a nonce. It is reachable after the signature and chain have already verified, for instance when an older timestamp carrying no nonce is replayed for the same artefact. Reject a response that lacks the expected nonce rather than dereferencing it, which also lines up with RFC 3161 2.4.2 requiring a requested nonce to be echoed back.