### PR TITLE
build: bump go directive to 1.25.11 to pull patched Go standard library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/timestamp-authority/v2
 
-go 1.25.0
+go 1.25.11
 
 require (
 	cloud.google.com/go/security v1.25.0


### PR DESCRIPTION
### Summary

The released `timestamp-server` image (`ghcr.io/sigstore/timestamp-server`) is built by `ko`, and the release workflow installs the Go toolchain via `actions/setup-go` with `go-version-file: './go.mod'`. The `go` directive is currently pinned to **`go 1.25.0`**, so the published binaries embed the Go 1.25.0 standard library, which has **30+ known CVEs** (1 CRITICAL, ~14 HIGH, the rest MEDIUM/LOW).

Bumping the directive to **1.25.11** (latest patched 1.25.x) makes the build use a Go standard library where all of these are fixed. This is a one-line change; no code changes are required.

### How this was found

A Trivy scan of `ghcr.io/sigstore/timestamp-server:v2.1.2` reports `stdlib v1.25.0` with the vulnerabilities below. They are also present in `v2.1.0` (1.25.1) and current `main`.

### Notable CVEs (all fixed in Go 1.25.11)

**CRITICAL**
- **CVE-2025-68121** — `crypto/tls`: incorrect certificate validation during TLS session resumption when `Config.ClientCAs`/`RootCAs` are mutated between the initial and resumed handshake (fixed in Go 1.24.13 / 1.25.7).

**HIGH (selection — mostly DoS via CPU/memory exhaustion on crafted input)**
- CVE-2025-61729 — `crypto/x509`: DoS via crafted certificate.
- CVE-2025-61726 — `net/url`: memory exhaustion parsing query parameters.
- CVE-2026-25679 — `net/url`: incorrect IPv6 host literal parsing.
- CVE-2026-32280 / CVE-2026-32281 — `crypto/x509`: DoS in certificate chain building/validation.
- CVE-2026-32283 — `crypto/tls`: DoS via repeated TLS 1.3 key-update messages.
- CVE-2026-33811 — `net`: DoS via long CNAME in `LookupCNAME`.
- CVE-2026-33814 — `net/http2`: transport can enter an infinite loop on crafted SETTINGS frames.
- CVE-2026-39820 / CVE-2026-42499 — `net/mail`: DoS in address parsing.

**MEDIUM/LOW** — ~20 more in `crypto/x509`, `crypto/tls`, `html/template` (XSS), `archive/tar`, `archive/zip`, `encoding/asn1`, `encoding/pem`, `net/textproto`, `os` (symlink escape), etc. All fixed in Go releases <= 1.25.11.

### Change

```diff
-go 1.25.0
+go 1.25.11
```

Since `release.yaml` and `build-snapshot.yaml` both use `go-version-file: './go.mod'`, no workflow changes are needed.

### Verification

After the bump, `go version` in CI reports `go1.25.11`, and a Trivy re-scan of the resulting image reports `stdlib v1.25.11` with the findings above cleared.
