### PR TITLE
Fix --timeout flag reporting its value type as "format" in help

### DIFF
--- a/cmd/timestamp-cli/app/pflags.go
+++ b/cmd/timestamp-cli/app/pflags.go
@@ -61,7 +61,7 @@ func initializePFlagMap() {
 		},
 		timeoutFlag: func() pflag.Value {
 			// this validates the timeout is >= 0
-			return valueFactory(formatFlag, validateTimeout, "")
+			return valueFactory(timeoutFlag, validateTimeout, "")
 		},
 	}
 }

--- a/cmd/timestamp-cli/app/pflags_test.go
+++ b/cmd/timestamp-cli/app/pflags_test.go
@@ -59,3 +59,22 @@ func TestValidateTimestampServerURL(t *testing.T) {
 		}
 	}
 }
+
+func TestFlagValueType(t *testing.T) {
+	tests := []struct {
+		flagType FlagType
+		want     string
+	}{
+		{fileFlag, "file"},
+		{urlFlag, "url"},
+		{oidFlag, "oid"},
+		{formatFlag, "format"},
+		{timeoutFlag, "timeout"},
+	}
+
+	for _, tc := range tests {
+		if got := NewFlagValue(tc.flagType, "").Type(); got != tc.want {
+			t.Errorf("Type() for %q = %q, want %q", tc.flagType, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Small help-text glitch in timestamp-cli: the persistent `--timeout` flag shows its value type as `format` instead of `timeout`.

```
--timeout format         HTTP timeout (default 30s)
```

It's a copy-paste slip in initializePFlagMap(): the timeoutFlag entry passes formatFlag to valueFactory (same literal as the format entry right above it). valueFactory stores that type and cobra renders it as the value-type hint in help, so timeout gets labeled format. Parsing is fine since validateTimeout uses the right type internally, so this is purely the help label. With the fix it reads `--timeout timeout`.

I added a small table test asserting each flag value reports its own type; it fails on the old code and passes after. go build/vet/test on ./cmd/timestamp-cli/... all pass. Thanks for taking a look.
