### PR TITLE
fail startup when the server config file cannot be read

### DIFF
--- a/cmd/timestamp-server/app/root.go
+++ b/cmd/timestamp-server/app/root.go
@@ -16,6 +16,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -116,8 +117,18 @@ func initConfig() {
 
 	viper.AutomaticEnv() // read in environment variables that match
 
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
+	// If a config file is found, read it in. A config file that exists but
+	// cannot be read or parsed must not be ignored: every setting would fall
+	// back to its flag default, and the default signer is the in-memory one,
+	// so the server would come up issuing timestamps under a self-signed key
+	// generated at startup instead of the configured KMS, Tink or file signer.
+	// Only "no config file anywhere in the search path" is benign.
+	if err := viper.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) {
+			log.Logger.Fatalf("error reading config file: %v", err)
+		}
+	} else {
 		log.Logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
 }


### PR DESCRIPTION
initConfig throws away the error from viper.ReadInConfig, so a config file that exists but is malformed or unreadable is silently ignored, and that includes one named explicitly with --config. Every setting then falls back to its flag default, and the default for timestamp-signer is memory, so NewAPI takes the in-memory branch and generates a throwaway self-signed chain at startup rather than using the configured KMS, Tink or file signer; the server comes up healthy and issues timestamps under that ephemeral key, with accepted-policy-oids and enforce-intermediate-eku quietly reverted too. I reproduced it by putting a YAML syntax error in a timestamp-server.yaml that selects the file signer: the server started with no complaint and /api/v1/timestamp/certchain served the built-in "Test TSA Root" chain. This now treats only ConfigFileNotFoundError as benign and makes any other read or parse error fatal, which is what timestamp-cli already does with the same call, so a config path that is given but cannot be read will fail at startup instead of being skipped.