### PR TITLE
allow crypto/x509 to generate serial number and skid

### DIFF
--- a/pkg/signer/memory.go
+++ b/pkg/signer/memory.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	tsx509 "github.com/sigstore/timestamp-authority/v2/pkg/x509"
 )
 
@@ -39,12 +38,7 @@ func NewTimestampingCertWithChain(signer crypto.Signer) ([]*x509.Certificate, er
 	if err != nil {
 		return nil, fmt.Errorf("generating in-memory root key")
 	}
-	sn, err := cryptoutils.GenerateSerialNumber()
-	if err != nil {
-		return nil, fmt.Errorf("generating root serial number: %w", err)
-	}
 	rootCA := &x509.Certificate{
-		SerialNumber: sn,
 		Subject: pkix.Name{
 			CommonName:   "Test TSA Root",
 			Organization: []string{"local"},
@@ -65,16 +59,11 @@ func NewTimestampingCertWithChain(signer crypto.Signer) ([]*x509.Certificate, er
 	}
 
 	// generate subordinate
-	sn, err = cryptoutils.GenerateSerialNumber()
-	if err != nil {
-		return nil, fmt.Errorf("generating subordinate serial number: %w", err)
-	}
 	subPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generating in-memory subordinate key")
 	}
 	subCA := &x509.Certificate{
-		SerialNumber: sn,
 		Subject: pkix.Name{
 			CommonName:   "Test TSA Intermediate",
 			Organization: []string{"local"},
@@ -96,31 +85,20 @@ func NewTimestampingCertWithChain(signer crypto.Signer) ([]*x509.Certificate, er
 	}
 
 	// generate leaf
-	sn, err = cryptoutils.GenerateSerialNumber()
-	if err != nil {
-		return nil, fmt.Errorf("generating leaf serial number: %w", err)
-	}
 	timestampExt, err := asn1.Marshal([]asn1.ObjectIdentifier{tsx509.EKUTimestampingOID})
 	if err != nil {
 		return nil, err
 	}
 
-	skid, err := cryptoutils.SKID(signer.Public())
-	if err != nil {
-		return nil, err
-	}
-
 	cert := &x509.Certificate{
-		SerialNumber: sn,
 		Subject: pkix.Name{
 			CommonName:   "Test TSA Timestamping",
 			Organization: []string{"local"},
 		},
-		SubjectKeyId: skid,
-		NotBefore:    now.Add(-3 * time.Minute),
-		NotAfter:     now.AddDate(9, 0, 0),
-		IsCA:         false,
-		KeyUsage:     x509.KeyUsageDigitalSignature,
+		NotBefore: now.Add(-3 * time.Minute),
+		NotAfter:  now.AddDate(9, 0, 0),
+		IsCA:      false,
+		KeyUsage:  x509.KeyUsageDigitalSignature,
 		// set EKU to x509.ExtKeyUsageTimeStamping but with a critical bit
 		ExtraExtensions: []pkix.Extension{
 			{


### PR DESCRIPTION
#### Summary

crypto/x509.CreateCertificate will generate a compliant serial number and SKID itself if one is not set in the template, no need to duplicate that functionality. Also, side-note, SKID in the leaf is redundant, and is only necessary in certificates with a basic constraints extension with cA: true (see https://tools.ietf.org/html/rfc5280#section-4.2.1.2).

#### Release Note

NONE

#### Documentation

This change is opaque to users.
