### PR TITLE
parse content-type header as a media type

### DIFF
--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"mime"
 	"net/http"
 	"slices"
 	"strings"
@@ -129,15 +130,20 @@ func parseDERRequest(reqBytes []byte) (*timestamp.Request, string, error) {
 }
 
 func getContentType(r *http.Request) (string, error) {
-	contentTypeHeader := r.Header.Get("Content-Type")
-	if strings.Count(contentTypeHeader, "application/") != 1 {
-		return "", errors.New("content-type header should specify application only once")
+	// Parse the header as a media type rather than searching for the
+	// "application/" substring. The substring match both refuses valid
+	// parameterised headers such as "application/json; charset=utf-8" and
+	// accepts unrelated types like "multipart/form-data; boundary=application/json",
+	// which then get routed to a parser based on the parameter value.
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse content-type header: %w", err)
 	}
-	splitHeader := strings.SplitN(contentTypeHeader, "application/", 2)
-	if len(splitHeader) != 2 {
-		return "", errors.New("expected header value to be split into two pieces")
+	subtype, ok := strings.CutPrefix(mediaType, "application/")
+	if !ok {
+		return "", errors.New("content-type must be an application media type")
 	}
-	return splitHeader[1], nil
+	return subtype, nil
 }
 
 func requestBodyToTimestampReq(reqBytes []byte, contentType string) (*timestamp.Request, string, error) {

--- a/pkg/api/timestamp_test.go
+++ b/pkg/api/timestamp_test.go
@@ -17,10 +17,51 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestGetContentType(t *testing.T) {
+	tests := []struct {
+		header      string
+		wantSubtype string
+		wantErr     bool
+	}{
+		{header: "application/json", wantSubtype: "json"},
+		{header: "application/timestamp-query", wantSubtype: "timestamp-query"},
+		// A media type parameter must not change the outcome.
+		{header: "application/json; charset=utf-8", wantSubtype: "json"},
+		{header: "application/timestamp-query; charset=utf-8", wantSubtype: "timestamp-query"},
+		// A parameter value that embeds "application/..." must not be
+		// mistaken for the media type.
+		{header: "multipart/form-data; boundary=application/json", wantErr: true},
+		{header: "text/plain", wantErr: true},
+		{header: "", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		r := &http.Request{Header: http.Header{}}
+		if tc.header != "" {
+			r.Header.Set("Content-Type", tc.header)
+		}
+		subtype, err := getContentType(r)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("header %q: expected an error, got subtype %q", tc.header, subtype)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("header %q: unexpected error: %v", tc.header, err)
+			continue
+		}
+		if subtype != tc.wantSubtype {
+			t.Errorf("header %q: expected subtype %q, got %q", tc.header, tc.wantSubtype, subtype)
+		}
+	}
+}
 
 func FuzzParseJSONRequest(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, reqBytes []byte) {


### PR DESCRIPTION
getContentType routes a timestamp request by counting and splitting the Content-Type header on the substring application/, so a standard header like application/json; charset=utf-8 is refused while an unrelated type such as multipart/form-data; boundary=application/json is accepted and handed to the JSON parser because its boundary parameter contains the substring. Both come from matching the raw header text rather than the actual media type on an unauthenticated request. Parse the header with mime.ParseMediaType and match the media type against application/ exactly, which drops any parameters before the content-type switch and rejects anything that is not really an application type.